### PR TITLE
Let AnyOptional conform to ExpressibleByNilLiteral

### DIFF
--- a/Sources/SpeziFoundation/Misc/AnyOptional.swift
+++ b/Sources/SpeziFoundation/Misc/AnyOptional.swift
@@ -1,6 +1,6 @@
 //
 // This source file is part of the Stanford Spezi open-source project.
-// It is based on the code from the Apodini (https://github.com/Apodini/Apodini) projects.
+// It is based on the code from the Apodini (https://github.com/Apodini/Apodini) project.
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md) and the Apodini project authors
 //
@@ -13,12 +13,12 @@
 /// This is useful to unwrapping, e.g.,  generics or associated types by declaring an extension under the condition of
 /// ``AnyOptional`` conformance. This allows in the implementation of the extension to access the underlying
 /// ``Wrapped`` type of an `Optional`, essentially unwrapping the optional type.
-public protocol AnyOptional {
+public protocol AnyOptional: ExpressibleByNilLiteral {
     /// The underlying type of the Optional
     associatedtype Wrapped
 
 
-    /// This property provides access
+    /// This property provides access to the underlying Optional
     var unwrappedOptional: Optional<Wrapped> { get }
     // swiftlint:disable:previous syntactic_sugar
     // Disabling syntactic_sugar, improves readability and showcases what really happens here.

--- a/Sources/SpeziFoundation/Misc/AnyOptional.swift
+++ b/Sources/SpeziFoundation/Misc/AnyOptional.swift
@@ -14,8 +14,8 @@
 /// ``AnyOptional`` conformance. This allows in the implementation of the extension to access the underlying
 /// ``Wrapped`` type of an `Optional`, essentially unwrapping the optional type.
 ///
-/// ``AnyOptional`` conforms to the `ExpressibleByNilLiteral` protocol.
-/// Apple states that only `Optional` conforms to the `ExpressibleByNilLiteral` protocol: https://developer.apple.com/documentation/swift/expressiblebynilliteral
+/// ``AnyOptional`` conforms to the [`ExpressibleByNilLiteral`](https://developer.apple.com/documentation/swift/expressiblebynilliteral) protocol.
+/// Apple states that only the `Optional` type conforms to `ExpressibleByNilLiteral`. `ExpressibleByNilLiteral` conformance for types that use `nil for other purposes is discouraged.
 public protocol AnyOptional: ExpressibleByNilLiteral {
     /// The underlying type of the Optional
     associatedtype Wrapped

--- a/Sources/SpeziFoundation/Misc/AnyOptional.swift
+++ b/Sources/SpeziFoundation/Misc/AnyOptional.swift
@@ -13,6 +13,9 @@
 /// This is useful to unwrapping, e.g.,  generics or associated types by declaring an extension under the condition of
 /// ``AnyOptional`` conformance. This allows in the implementation of the extension to access the underlying
 /// ``Wrapped`` type of an `Optional`, essentially unwrapping the optional type.
+///
+/// ``AnyOptional`` conforms to the `ExpressibleByNilLiteral` protocol.
+/// Apple states that only `Optional` conforms to the `ExpressibleByNilLiteral` protocol: https://developer.apple.com/documentation/swift/expressiblebynilliteral
 public protocol AnyOptional: ExpressibleByNilLiteral {
     /// The underlying type of the Optional
     associatedtype Wrapped


### PR DESCRIPTION
# Let AnyOptional conform to ExpressibleByNilLiteral

## :recycle: Current situation & Problem
As of now, our `AnyOptional` type doesn't conform to the `ExpressibleByNilLiteral` protocol. 
Apple states that only `Optional` conforms to `ExpressibleByNilLiteral`: https://developer.apple.com/documentation/swift/expressiblebynilliteral


## :gear: Release Notes 
- Add conformance of `AnyOptional` to `ExpressibleByNilLiteral`


## :books: Documentation
Small typo fix and in-line docs added


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
