### PR TITLE
Add support for visionOS, macOS and tvOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,13 +67,14 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       codeql: true
+      test: false
       scheme: SpeziFoundation
     permissions:
       security-events: write
       actions: read
   uploadcoveragereport:
     name: Upload Coverage Report
-    needs: [packageios, packagewatchos, packagevisionos]
+    needs: [packageios, packagewatchos, packagevisionos, packagetvos, packagemacos]
     uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
       coveragereports: SpeziFoundation.xcresult SpeziFoundationWatchOS.xcresult SpeziFoundationVisionOS.xcresult SpeziFoundationTvOS.xcresult SpeziFoundationMacOS.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,6 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       codeql: true
-      xcodeversion: '14.3.1'
       scheme: SpeziFoundation
     permissions:
       security-events: write

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,11 +64,11 @@ jobs:
       artifactname: SpeziFoundationMacOS.xcresult
   codeql:
     name: CodeQL
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       codeql: true
       xcodeversion: '14.3.1'
-      scheme: TemplatePackage
+      scheme: SpeziFoundation
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,9 +42,39 @@ jobs:
       resultBundle: SpeziFoundationVisionOS.xcresult
       destination: 'platform=visionOS Simulator,name=Apple Vision Pro'
       artifactname: SpeziFoundationVisionOS.xcresult
+  packagetvos:
+    name: Build and Test Swift Package tvOS
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macOS", "self-hosted"]'
+      xcodeversion: latest
+      scheme: SpeziFoundation
+      resultBundle: SpeziFoundationTvOS.xcresult
+      destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'
+      artifactname: SpeziFoundationTvOS.xcresult
+  packagemacos:
+    name: Build and Test Swift Package macOS
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macOS", "self-hosted"]'
+      xcodeversion: latest
+      scheme: SpeziFoundation
+      resultBundle: SpeziFoundationMacOS.xcresult
+      destination: 'platform=macOS,arch=arm64'
+      artifactname: SpeziFoundationMacOS.xcresult
+  codeql:
+    name: CodeQL
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      codeql: true
+      xcodeversion: '14.3.1'
+      scheme: TemplatePackage
+    permissions:
+      security-events: write
+      actions: read
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: [packageios, packagewatchos, packagevisionos]
     uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
-      coveragereports: SpeziFoundation.xcresult SpeziFoundationWatchOS.xcresult SpeziFoundationVisionOS.xcresult
+      coveragereports: SpeziFoundation.xcresult SpeziFoundationWatchOS.xcresult SpeziFoundationVisionOS.xcresult SpeziFoundationTvOS.xcresult.xcresult SpeziFoundationMacOS.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziFoundation
       resultBundle: SpeziFoundationWatchOS.xcresult
-      destination: 'platform=watchOS Simulator,name=Apple Watch Series 8 (45mm)'
+      destination: 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)'
       artifactname: SpeziFoundationWatchOS.xcresult
   packagevisionos:
     name: Build and Test Swift Package visionOS
@@ -76,4 +76,4 @@ jobs:
     needs: [packageios, packagewatchos, packagevisionos]
     uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
-      coveragereports: SpeziFoundation.xcresult SpeziFoundationWatchOS.xcresult SpeziFoundationVisionOS.xcresult SpeziFoundationTvOS.xcresult.xcresult SpeziFoundationMacOS.xcresult
+      coveragereports: SpeziFoundation.xcresult SpeziFoundationWatchOS.xcresult SpeziFoundationVisionOS.xcresult SpeziFoundationTvOS.xcresult SpeziFoundationMacOS.xcresult

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,5 +12,9 @@ authors:
 - family-names: "Schmiedmayer"
   given-names: "Paul"
   orcid: "https://orcid.org/0000-0002-8607-9148"
+- family-names: "Bauer"
+  given-names: "Andreas"
+  orcid: "https://orcid.org/0000-0002-1680-237X"
 title: "SpeziFoundation"
+doi: 10.5281/zenodo.10077558
 url: "https://github.com/StanfordSpezi/SpeziFoundation"

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,7 @@ let package = Package(
         .watchOS(.v10),
         .visionOS(.v1),
         .macOS(.v14),
-        .tvOS(.v17),
-        .macCatalyst(.v17)
+        .tvOS(.v17)
     ],
     products: [
         .library(name: "SpeziFoundation", targets: ["SpeziFoundation"])

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,11 @@ let package = Package(
     name: "SpeziFoundation",
     platforms: [
         .iOS(.v17),
-        .watchOS(.v10)
+        .watchOS(.v10),
+        .visionOS(.v1),
+        .macOS(.v14),
+        .tvOS(.v17),
+        .macCatalyst(.v17)
     ],
     products: [
         .library(name: "SpeziFoundation", targets: ["SpeziFoundation"])

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ SPDX-License-Identifier: MIT
 # SpeziFoundation
 
 [![Build and Test](https://github.com/StanfordSpezi/SpeziFoundation/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/StanfordSpezi/SpeziFoundation/actions/workflows/build-and-test.yml)
+[![codecov](https://codecov.io/gh/StanfordSpezi/SpeziFoundation/graph/badge.svg?token=9S5PQRVKF8)](https://codecov.io/gh/StanfordSpezi/SpeziFoundation)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10077558.svg)](https://doi.org/10.5281/zenodo.10077558)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziFoundation%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/StanfordSpezi/SpeziFoundation)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziFoundation%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/StanfordSpezi/SpeziFoundation)
 
 Spezi Foundation provides a base layer of functionality useful in many applications, including fundamental types, algorithms, extensions, and data structures.
 


### PR DESCRIPTION
# Add support for visionOS, macOS and tvOS

## :recycle: Current situation & Problem
This PR adds support for visionOS, macOS and tvOS. These are not major changes and only required changes within the Package.swift file.


## :gear: Release Notes 
* Add support for visionOS, macOS and tvOS


## :books: Documentation
-


## :white_check_mark: Testing
We are currently testing iOS, watchOS and visionOS in CI.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
