### PR TITLE
`runOrScheduleOnMainActor` function

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziFoundation
       resultBundle: SpeziFoundationWatchOS.xcresult
-      destination: 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)'
+      destination: 'platform=watchOS Simulator,name=Apple Watch 10 (46mm)'
       artifactname: SpeziFoundationWatchOS.xcresult
   packagevisionos:
     name: Build and Test Swift Package visionOS

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziFoundation
       resultBundle: SpeziFoundationWatchOS.xcresult
-      destination: 'platform=watchOS Simulator,name=Apple Watch 10 (46mm)'
+      destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)'
       artifactname: SpeziFoundationWatchOS.xcresult
   packagevisionos:
     name: Build and Test Swift Package visionOS

--- a/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
+++ b/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
@@ -11,7 +11,7 @@ import Foundation
 
 /// Runs or schedules a closure on the `MainActor`, depending on the current execution context.
 /// If the function is already running on the `MainActor`, the closure will be invoked immediately.
-/// If the function is not running on the `MainActor`, an invocation of the closure will be scheduled onto the `MainActor`.
+/// Otherwise, an invocation of the closure will be scheduled onto the `MainActor`.
 public func runOrScheduleOnMainActor(
     _ block: @MainActor @escaping () -> Void
 ) {

--- a/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
+++ b/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
@@ -12,7 +12,7 @@ import Foundation
 /// Runs or schedules a closure on the `MainActor`, depending on the current execution context.
 /// If the function is already running on the `MainActor`, the closure will be invoked immediately.
 /// If the function is not running on the `MainActor`, an invocation of the closure will be scheduled onto the `MainActor`.
-public func RunOrScheduleOnMainActor(
+public func runOrScheduleOnMainActor(
     _ block: @MainActor @escaping () -> Void
 ) {
     if Thread.isMainThread {

--- a/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
+++ b/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
@@ -1,0 +1,27 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+/// Runs or schedules a closure on the `MainActor`, depending on the current execution context.
+/// If the function is already running on the `MainActor`, the closure will be invoked immediately.
+/// If the function is not running on the `MainActor`, an invocation of the closure will be scheduled onto the `MainActor`.
+public func RunOrScheduleOnMainActor(
+    _ block: @MainActor @escaping () -> Void
+) {
+    if Thread.isMainThread {
+        MainActor.assumeIsolated {
+            block()
+        }
+    } else {
+        Task { @MainActor in
+            block()
+        }
+    }
+}

--- a/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
+++ b/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
@@ -1,0 +1,45 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+import SpeziFoundation
+import XCTest
+
+
+@globalActor
+actor TestActor: GlobalActor {
+    let queue = DispatchQueue(label: "Queueeee") as! DispatchSerialQueue
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+        queue.asUnownedSerialExecutor()
+    }
+    static let shared = TestActor()
+}
+
+
+final class MainActorExecutionTests: XCTestCase {
+    func testIfAlreadyRunningOnMainActor() {
+        // XCTest by default runs all test cases on the main thread, ie the main queue, ie the main actor.
+        dispatchPrecondition(condition: .onQueue(.main))
+        var didRun = false
+        RunOrScheduleOnMainActor {
+            didRun = true
+        }
+        XCTAssertTrue(didRun)
+    }
+    
+    @TestActor
+    func testIfRunningOffTheMainActor() async {
+        dispatchPrecondition(condition: .notOnQueue(.main))
+        dispatchPrecondition(condition: .onQueue(TestActor.shared.queue))
+        var didRun = false
+        RunOrScheduleOnMainActor {
+            didRun = true
+        }
+        XCTAssertFalse(didRun)
+    }
+}

--- a/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
+++ b/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
@@ -15,7 +15,7 @@ import XCTest
 @globalActor
 private actor TestActor: GlobalActor {
     static let shared = TestActor()
-    let queue = DispatchQueue(label: "Queueeee") as! DispatchSerialQueue // swiftlint:disable:this force_cast
+    let queue = DispatchQueue(label: "Queue") as! DispatchSerialQueue // swiftlint:disable:this force_cast
     nonisolated var unownedExecutor: UnownedSerialExecutor {
         queue.asUnownedSerialExecutor()
     }

--- a/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
+++ b/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
@@ -36,10 +36,10 @@ final class MainActorExecutionTests: XCTestCase {
     func testIfRunningOffTheMainActor() async {
         dispatchPrecondition(condition: .notOnQueue(.main))
         dispatchPrecondition(condition: .onQueue(TestActor.shared.queue))
-        var didRun = false
+        let expectation = self.expectation(description: "ran on main actor")
         runOrScheduleOnMainActor {
-            didRun = true
+            expectation.fulfill()
         }
-        XCTAssertFalse(didRun)
+        await fulfillment(of: [expectation])
     }
 }

--- a/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
+++ b/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
@@ -11,8 +11,9 @@ import SpeziFoundation
 import XCTest
 
 
+/// Internal helper actor to be able to have code run guaranteed off the main actor (by scheduling it onto a background queue)
 @globalActor
-actor TestActor: GlobalActor {
+private actor TestActor: GlobalActor {
     static let shared = TestActor()
     let queue = DispatchQueue(label: "Queueeee") as! DispatchSerialQueue // swiftlint:disable:this force_cast
     nonisolated var unownedExecutor: UnownedSerialExecutor {

--- a/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
+++ b/Tests/SpeziFoundationTests/MainActorExecutionTests.swift
@@ -13,11 +13,11 @@ import XCTest
 
 @globalActor
 actor TestActor: GlobalActor {
-    let queue = DispatchQueue(label: "Queueeee") as! DispatchSerialQueue
+    static let shared = TestActor()
+    let queue = DispatchQueue(label: "Queueeee") as! DispatchSerialQueue // swiftlint:disable:this force_cast
     nonisolated var unownedExecutor: UnownedSerialExecutor {
         queue.asUnownedSerialExecutor()
     }
-    static let shared = TestActor()
 }
 
 
@@ -26,7 +26,7 @@ final class MainActorExecutionTests: XCTestCase {
         // XCTest by default runs all test cases on the main thread, ie the main queue, ie the main actor.
         dispatchPrecondition(condition: .onQueue(.main))
         var didRun = false
-        RunOrScheduleOnMainActor {
+        runOrScheduleOnMainActor {
             didRun = true
         }
         XCTAssertTrue(didRun)
@@ -37,7 +37,7 @@ final class MainActorExecutionTests: XCTestCase {
         dispatchPrecondition(condition: .notOnQueue(.main))
         dispatchPrecondition(condition: .onQueue(TestActor.shared.queue))
         var didRun = false
-        RunOrScheduleOnMainActor {
+        runOrScheduleOnMainActor {
             didRun = true
         }
         XCTAssertFalse(didRun)


### PR DESCRIPTION
# `runOrScheduleOnMainActor` function

## :recycle: Current situation & Problem
As part of dealing with the `onPreferenceChange` API changes, we ended up having to duplicate code in a bunch of places, in a way that always used the same fundamental pattern (ie, if we're on the MainActor, run a piece of code directly, otherwise schedule it onto the MainActor).
This PR simply abstracts this into a new global `func runOrScheduleOnMainActor`.


## :gear: Release Notes 
- Added `runOrScheduleOnMainActor` function


## :books: Documentation
n/a; all new code is directly documented.


## :white_check_mark: Testing
there are new test cases for the new function


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
