### PR TITLE
add Duration and KeyValuePairs extensions

### DIFF
--- a/Sources/SpeziFoundation/Misc/Duration.swift
+++ b/Sources/SpeziFoundation/Misc/Duration.swift
@@ -20,7 +20,7 @@ extension Duration {
     public static func minutes(_ minutes: some BinaryInteger) -> Duration {
         .seconds(minutes * 60)
     }
-
+    
     /// A duration given a number of minutes.
     ///
     /// Creates a new duration given a number of minutes by converting into the closest second scale value.
@@ -33,7 +33,7 @@ extension Duration {
     public static func minutes(_ minutes: Double) -> Duration {
         .seconds(minutes * 60)
     }
-
+    
     /// A duration given a number of hours.
     ///
     /// ```swift
@@ -44,7 +44,7 @@ extension Duration {
     public static func hours(_ hours: some BinaryInteger) -> Duration {
         .seconds(hours * 60 * 60)
     }
-
+    
     /// A duration given a number of hours.
     ///
     /// Creates a new duration given a number of hours by converting into the closest second scale value.
@@ -57,7 +57,7 @@ extension Duration {
     public static func hours(_ hours: Double) -> Duration {
         .seconds(hours * 60 * 60)
     }
-
+    
     /// A duration given a number of days.
     ///
     /// ```swift
@@ -68,7 +68,7 @@ extension Duration {
     public static func days(_ days: some BinaryInteger) -> Duration {
         .seconds(days * 60 * 60 * 24)
     }
-
+    
     /// A duration given a number of days.
     ///
     /// ```swift
@@ -79,7 +79,7 @@ extension Duration {
     public static func days(_ days: Double) -> Duration {
         .seconds(days * 60 * 60 * 24)
     }
-
+    
     /// A duration given a number of weeks.
     ///
     /// ```swift
@@ -90,7 +90,7 @@ extension Duration {
     public static func weeks(_ weeks: some BinaryInteger) -> Duration {
         .seconds(weeks * 60 * 60 * 24 * 7)
     }
-
+    
     /// A duration given a number of weeks.
     ///
     /// ```swift
@@ -101,11 +101,12 @@ extension Duration {
     public static func weeks(_ weeks: Double) -> Duration {
         .seconds(weeks * 60 * 60 * 24 * 7)
     }
-    
-    
+}
+
+
+extension Duration {
     /// The number of seconds in the `Duration`, as a `TimeInterval` value.
-    @inlinable
-    public var timeInterval: TimeInterval {
+    @inlinable public var timeInterval: TimeInterval {
         let components = self.components
         let attosecondsInSeconds = Double(components.attoseconds) / 1_000_000_000_000_000_000.0 // 10^-18
         return TimeInterval(components.seconds) + attosecondsInSeconds

--- a/Sources/SpeziFoundation/Misc/Duration.swift
+++ b/Sources/SpeziFoundation/Misc/Duration.swift
@@ -1,0 +1,113 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension Duration {
+    /// A duration given a number of minutes.
+    ///
+    /// ```swift
+    /// let duration: Duration = .minutes(27)
+    /// ```
+    /// - Returns: A `Duration` representing a given number of minutes.
+    @inlinable
+    public static func minutes(_ minutes: some BinaryInteger) -> Duration {
+        .seconds(minutes * 60)
+    }
+
+    /// A duration given a number of minutes.
+    ///
+    /// Creates a new duration given a number of minutes by converting into the closest second scale value.
+    ///
+    /// ```swift
+    /// let duration: Duration = .minutes(27.5)
+    /// ```
+    /// - Returns: A `Duration` representing a given number of minutes.
+    @inlinable
+    public static func minutes(_ minutes: Double) -> Duration {
+        .seconds(minutes * 60)
+    }
+
+    /// A duration given a number of hours.
+    ///
+    /// ```swift
+    /// let duration: Duration = .hours(4)
+    /// ```
+    /// - Returns: A `Duration` representing a given number of hours.
+    @inlinable
+    public static func hours(_ hours: some BinaryInteger) -> Duration {
+        .seconds(hours * 60 * 60)
+    }
+
+    /// A duration given a number of hours.
+    ///
+    /// Creates a new duration given a number of hours by converting into the closest second scale value.
+    ///
+    /// ```swift
+    /// let duration: Duration = .hours(4.5)
+    /// ```
+    /// - Returns: A `Duration` representing a given number of hours.
+    @inlinable
+    public static func hours(_ hours: Double) -> Duration {
+        .seconds(hours * 60 * 60)
+    }
+
+    /// A duration given a number of days.
+    ///
+    /// ```swift
+    /// let duration: Duration = .days(2)
+    /// ```
+    /// - Returns: A `Duration` representing a given number of days.
+    @inlinable
+    public static func days(_ days: some BinaryInteger) -> Duration {
+        .seconds(days * 60 * 60 * 24)
+    }
+
+    /// A duration given a number of days.
+    ///
+    /// ```swift
+    /// let duration: Duration = .days(2.5)
+    /// ```
+    /// - Returns: A `Duration` representing a given number of days.
+    @inlinable
+    public static func days(_ days: Double) -> Duration {
+        .seconds(days * 60 * 60 * 24)
+    }
+
+    /// A duration given a number of weeks.
+    ///
+    /// ```swift
+    /// let duration: Duration = .weeks(4)
+    /// ```
+    /// - Returns: A `Duration` representing a given number of weeks.
+    @inlinable
+    public static func weeks(_ weeks: some BinaryInteger) -> Duration {
+        .seconds(weeks * 60 * 60 * 24 * 7)
+    }
+
+    /// A duration given a number of weeks.
+    ///
+    /// ```swift
+    /// let duration: Duration = .weeks(3.5)
+    /// ```
+    /// - Returns: A `Duration` representing a given number of weeks.
+    @inlinable
+    public static func weeks(_ weeks: Double) -> Duration {
+        .seconds(weeks * 60 * 60 * 24 * 7)
+    }
+    
+    
+    /// The number of seconds in the `Duration`, as a `TimeInterval` value.
+    @inlinable
+    public var timeInterval: TimeInterval {
+        let components = self.components
+        let attosecondsInSeconds = Double(components.attoseconds) / 1_000_000_000_000_000_000.0 // 10^-18
+        return TimeInterval(components.seconds) + attosecondsInSeconds
+    }
+}

--- a/Sources/SpeziFoundation/Misc/KeyValuePairs.swift
+++ b/Sources/SpeziFoundation/Misc/KeyValuePairs.swift
@@ -1,0 +1,18 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+extension KeyValuePairs {
+    /// Creates a `KeyValuePairs` object, using the elements of a `Sequence`.
+    /// - parameter seq: The Sequence whose elements should be used as the key-value pairs of the resulting `KeyValuePairs` instance.
+    @inlinable
+    public init<S: Sequence>(_ seq: S) where S.Element == (Key, Value) {
+        let initFn = unsafeBitCast(Self.init(dictionaryLiteral:), to: (([S.Element]) -> Self).self)
+        self = initFn(Array(seq))
+    }
+}

--- a/Tests/SpeziFoundationTests/DurationTests.swift
+++ b/Tests/SpeziFoundationTests/DurationTests.swift
@@ -1,0 +1,30 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+@testable import SpeziFoundation
+import Testing
+
+
+struct DurationTests {
+    @Test
+    func factoryMethodsAndTimeInterval() throws {
+        let minute: TimeInterval = 60
+        let hour: TimeInterval = minute * 60
+        let day: TimeInterval = hour * 24
+        let week: TimeInterval = day * 7
+        #expect(Duration.minutes(4).timeInterval == minute * 4)
+        #expect(Duration.minutes(4.7).timeInterval == minute * 4.7)
+        #expect(Duration.hours(4).timeInterval == hour * 4)
+        #expect(Duration.hours(4.7).timeInterval == hour * 4.7)
+        #expect(Duration.days(4).timeInterval == day * 4)
+        #expect(Duration.days(4.7).timeInterval == day * 4.7)
+        #expect(Duration.weeks(4 as Int).timeInterval == week * 4)
+        #expect(Duration.weeks(4.7).timeInterval == week * 4.7)
+    }
+}

--- a/Tests/SpeziFoundationTests/KeyValuePairsTests.swift
+++ b/Tests/SpeziFoundationTests/KeyValuePairsTests.swift
@@ -1,0 +1,48 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+import SpeziFoundation
+import XCTest
+
+
+private func XCTAssertEqual<A: Hashable, B: Equatable>(
+    _ lhs: KeyValuePairs<A, B>,
+    _ rhs: KeyValuePairs<A, B>,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    let lhs = Dictionary<A, B>(lhs.lazy.map { ($0, $1) }, uniquingKeysWith: { a, b in a })
+    let rhs = Dictionary<A, B>(rhs.lazy.map { ($0, $1) }, uniquingKeysWith: { a, b in a })
+    if lhs != rhs {
+        XCTFail("'\(lhs)' was not equal to '\(rhs)'", file: file, line: line)
+    }
+}
+
+
+final class KeyValuePairsTests: XCTestCase {
+    func testCreateKeyValuePairsFromSequence() {
+        let sequence: some Sequence<(String, Int)> = [
+            ("A", 1), ("B", 2), ("C", 3), ("D", 4), ("E", 5), ("F", 6)
+        ]
+        XCTAssertEqual(
+            KeyValuePairs(sequence),
+            ["A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6]
+        )
+    }
+    
+    func testCreateKeyValuePairsFromDictionary() {
+        let dictionary = [
+            "A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6
+        ]
+        XCTAssertEqual(
+            KeyValuePairs(dictionary.lazy.map { ($0, $1) }),
+            ["A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6]
+        )
+    }
+}

--- a/Tests/SpeziFoundationTests/KeyValuePairsTests.swift
+++ b/Tests/SpeziFoundationTests/KeyValuePairsTests.swift
@@ -11,14 +11,17 @@ import SpeziFoundation
 import XCTest
 
 
-private func XCTAssertEqual<A: Hashable, B: Equatable>(
-    _ lhs: KeyValuePairs<A, B>,
-    _ rhs: KeyValuePairs<A, B>,
+private func XCTAssertEqual<Key: Hashable, Value: Equatable>(
+    _ lhs: KeyValuePairs<Key, Value>,
+    _ rhs: KeyValuePairs<Key, Value>,
     file: StaticString = #filePath,
     line: UInt = #line
-) {
-    let lhs = Dictionary<A, B>(lhs.lazy.map { ($0, $1) }, uniquingKeysWith: { a, b in a })
-    let rhs = Dictionary<A, B>(rhs.lazy.map { ($0, $1) }, uniquingKeysWith: { a, b in a })
+) throws {
+    let duplicateEntriesError = NSError(domain: "edu.stanford.spezi", code: 0, userInfo: [
+        NSLocalizedDescriptionKey: "Duplicate keys!"
+    ])
+    let lhs = try Dictionary(lhs.lazy.map { ($0, $1) }, uniquingKeysWith: { _, _ in throw duplicateEntriesError })
+    let rhs = try Dictionary(rhs.lazy.map { ($0, $1) }, uniquingKeysWith: { _, _ in throw duplicateEntriesError })
     if lhs != rhs {
         XCTFail("'\(lhs)' was not equal to '\(rhs)'", file: file, line: line)
     }
@@ -26,21 +29,21 @@ private func XCTAssertEqual<A: Hashable, B: Equatable>(
 
 
 final class KeyValuePairsTests: XCTestCase {
-    func testCreateKeyValuePairsFromSequence() {
+    func testCreateKeyValuePairsFromSequence() throws {
         let sequence: some Sequence<(String, Int)> = [
             ("A", 1), ("B", 2), ("C", 3), ("D", 4), ("E", 5), ("F", 6)
         ]
-        XCTAssertEqual(
+        try XCTAssertEqual(
             KeyValuePairs(sequence),
             ["A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6]
         )
     }
     
-    func testCreateKeyValuePairsFromDictionary() {
+    func testCreateKeyValuePairsFromDictionary() throws {
         let dictionary = [
             "A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6
         ]
-        XCTAssertEqual(
+        try XCTAssertEqual(
             KeyValuePairs(dictionary.lazy.map { ($0, $1) }),
             ["A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6]
         )


### PR DESCRIPTION
# `Duration` and `KeyValuePairs` extensions

## :recycle: Current situation & Problem
This PR moves into SpeziFoundation some extensions on `Duration` and `KeyValuePairs` which are currently in some of the individual Spezi modules. Especially the `Duration` extensions are nice to have in here, since the type is used in a couple of places.

## :gear: Release Notes 
- added `Duration.minutes(_:)`, `.hours(_:)`, `.days(_:)`, and `.weeks(_:)`
- added `Duration.timeInterval`
- Added `KeyValuePairs.init(_: some Sequence<(Key, Value)>)`

## :books: Documentation
new code is documented


## :white_check_mark: Testing
new code has full test coverage


## :pencil: Code of Conduct & Contributing Guidelines 
By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
