### PR TITLE
add `StaticString: Hashable` conformance

### DIFF
--- a/Sources/SpeziFoundation/Misc/StaticString+Hashable.swift
+++ b/Sources/SpeziFoundation/Misc/StaticString+Hashable.swift
@@ -1,0 +1,40 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+// SAFETY: We're declaring a retroactive conformance here, i.e. we are extending a type we don't own by making it conform to a protocol we don't own.
+// This is fine, in this specific case, since `StaticString` is a frozen type, meaning that we can safely assume that its layout and public properties
+// won't change. Furthermore, in this specific case there really is only one sensible way of implementing this.
+// Should this ever get added to the Standard Library, we should remove this conformance.
+extension StaticString: @retroactive Hashable {
+    /// Compares two `StaticString` instances for equality.
+    ///
+    /// This function returns `true` iff `lhs` and `rhs` have the same contents, otherwise `false`.
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs.hasPointerRepresentation, rhs.hasPointerRepresentation) {
+        case (true, true):
+            // the two strings are either truly identical (if they point to the same address),
+            // or they point to different memory locations which then contain identical contents
+            lhs.utf8Start == rhs.utf8Start || strcmp(lhs.utf8Start, rhs.utf8Start) == 0
+        case (false, false):
+            lhs.unicodeScalar == rhs.unicodeScalar
+        case (true, false), (false, true):
+            false
+        }
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        if self.hasPointerRepresentation {
+            hasher.combine(self.utf8Start)
+        } else {
+            hasher.combine(self.unicodeScalar)
+        }
+    }
+}

--- a/Tests/SpeziFoundationTests/StaticStringTests.swift
+++ b/Tests/SpeziFoundationTests/StaticStringTests.swift
@@ -1,0 +1,36 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+// swiftlint:disable identical_operands
+
+import Foundation
+@testable import SpeziFoundation
+import Testing
+
+
+/// helper function to get a `StaticString` from a literal without having to write `as StaticString` everywhere.
+@_transparent
+private func s(_ string: StaticString) -> StaticString {
+    string
+}
+
+struct StaticStringTests {
+    @Test
+    func equality() {
+        #expect(s("abc") == s("abc"))
+        #expect(s("def") == s("def"))
+        #expect(s("abc") != s("def"))
+    }
+    
+    @Test
+    func hashing() {
+        #expect(s("abc").hashValue == s("abc").hashValue)
+        #expect(s("def").hashValue == s("def").hashValue)
+        #expect(s("abc").hashValue != s("def").hashValue)
+    }
+}


### PR DESCRIPTION
# add `StaticString: Hashable` conformance

## :recycle: Current situation & Problem
Swift's `StaticString` type conforms neither to `Hashable`, nor to `Equatable`.
This PR adds conformances for both these protocols.
Why is this required? `StaticString`s are oftentimes used when working with eg the `#fileID` or `#filePath` macros. In circumstances when these values are used as identifiers for other things, we need the ability to compare and/or hash them.

See the changes for an explanation of why (in my humble opinion) adding this conformance is ok.


## :gear: Release Notes
- added `StaticString: Hashable` conformance


## :books: Documentation
the new functions are documented.


## :white_check_mark: Testing
the new functions are tested.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
