### PR TITLE
add `Sequence.{flat,compact}MapIntoSet`

### DIFF
--- a/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
+++ b/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
@@ -12,8 +12,8 @@ import Algorithms
 extension Sequence {
     /// Maps a `Sequence` into a `Set`.
     ///
-    /// Compared to instead mapping the sequence into an Array (the default `map` function's return type) and then constructing a `Set` from that,
-    /// this implementation can offer improved performance, since the intermediate Array is skipped.
+    /// Compared to instead mapping the sequence into an `Array` (the default `map` function's return type) and then constructing a `Set` from that,
+    /// this implementation can offer improved performance, since the intermediate `Array` is skipped.
     /// - Returns: a `Set` containing the results of applying `transform` to each element in the sequence.
     @inlinable
     public func mapIntoSet<NewElement: Hashable>(_ transform: (Element) throws -> NewElement) rethrows -> Set<NewElement> {
@@ -23,6 +23,39 @@ extension Sequence {
         }
         return retval
     }
+    
+    /// Maps a `Sequence` into a `Set`, skipping any `nil` elements.
+    ///
+    /// Compared to instead compact-mapping the sequence into an `Array` (the default `compactMap` function's return type) and then constructing a `Set` from that,
+    /// this implementation can offer improved performance, since the intermediate `Array` is skipped.
+    /// - Returns: a `Set` containing the results of applying `transform` to each element in the sequence, skipping all `nil` results.
+    @inlinable
+    public func compactMapIntoSet<NewElement: Hashable>(_ transform: (Element) throws -> NewElement?) rethrows -> Set<NewElement> {
+        var retval = Set<NewElement>()
+        for element in self {
+            if let element = try transform(element) {
+                retval.insert(element)
+            }
+        }
+        return retval
+    }
+    
+    /// Maps a `Sequence` into a `Set`, flattening the results of calling the `transform` closure with each element of the sequence.
+    ///
+    /// Compared to instead flat-mapping the sequence into an `Array` (the default `flatMap` function's return type) and then constructing a `Set` from that,
+    /// this implementation can offer improved performance, since the intermediate `Array` is skipped.
+    /// - Returns: a `Set` containing the flattened results of applying `transform` to each element in the sequence.
+    @inlinable
+    public func flatMapIntoSet<TransformResult: Sequence>(
+        _ transform: (Element) throws -> TransformResult
+    ) rethrows -> Set<TransformResult.Element> {
+        var retval = Set<TransformResult.Element>()
+        for element in self {
+            retval.formUnion(try transform(element))
+        }
+        return retval
+    }
+    
     
     /// An asynchronous version of Swift's `Sequence.reduce(_:_:)` function.
     @inlinable

--- a/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
+++ b/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
@@ -48,7 +48,7 @@ extension Sequence {
     @inlinable
     public func flatMapIntoSet<TransformResult: Sequence>(
         _ transform: (Element) throws -> TransformResult
-    ) rethrows -> Set<TransformResult.Element> {
+    ) rethrows -> Set<TransformResult.Element> where TransformResult.Element: Hashable {
         var retval = Set<TransformResult.Element>()
         for element in self {
             retval.formUnion(try transform(element))

--- a/Tests/SpeziFoundationTests/SequenceExtensionTests.swift
+++ b/Tests/SpeziFoundationTests/SequenceExtensionTests.swift
@@ -6,43 +6,64 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Foundation
 import SpeziFoundation
-import XCTest
+import Testing
 
 
-final class SequenceExtensionTests: XCTestCase {
-    func testMapIntoSet() {
-        XCTAssertEqual([0, 1, 2, 3, 4].mapIntoSet { $0 * 2 }, [0, 2, 4, 6, 8])
-        XCTAssertEqual([0, 1, 2, 3, 4].mapIntoSet { $0 / 2 }, [0, 1, 2])
+@Suite
+struct SequenceExtensions {
+    @Test
+    func mapIntoSet() {
+        #expect([0, 1, 2, 3, 4].mapIntoSet { $0 * 2 } == [0, 2, 4, 6, 8])
+        #expect([0, 1, 2, 3, 4].mapIntoSet { $0 / 2 } == [0, 1, 2])
     }
     
+    @Test
+    func compactMapIntoSet() {
+        #expect([0, 1, 2, 3, 4].compactMapIntoSet { $0.isMultiple(of: 2) ? $0 * 2 : nil } == [0, 4, 8])
+        #expect([0, 1, 2, 3, 4].compactMapIntoSet { $0.isMultiple(of: 2) ? $0 / 2 : nil } == [0, 1, 2])
+    }
     
-    func testRemoveAtIndices() {
+    @Test
+    func flatMapIntoSet() {
+        struct Person {
+            let name: String
+            let petNames: [String]
+        }
+        let lukas = Person(name: "Lukas", petNames: ["Snugglebug", "Tofu", "Clover", "Muffin"])
+        let paul = Person(name: "Paul", petNames: ["Pudding", "Sprout", "Clover"])
+        #expect([paul, lukas].flatMapIntoSet(\.petNames) == ["Snugglebug", "Tofu", "Clover", "Pudding", "Muffin", "Sprout"])
+    }
+    
+    @Test
+    func removeAtIndices() {
         var array = Array(0...9)
         array.remove(at: [0, 7, 5, 2])
-        XCTAssertEqual(array, [1, 3, 4, 6, 8, 9])
+        #expect(array == [1, 3, 4, 6, 8, 9])
         
         array = Array(0...9)
         array.remove(at: [0, 7, 5, 2] as IndexSet)
-        XCTAssertEqual(array, [1, 3, 4, 6, 8, 9])
+        #expect(array == [1, 3, 4, 6, 8, 9])
     }
     
-    
-    func testAsyncReduce() async throws {
+    @Test
+    func asyncReduce() async throws {
         let names = ["Paul", "Lukas"]
         let reduced = try await names.reduce(0) { acc, name in
             try await Task.sleep(for: .seconds(0.2)) // best i could think of to get some trivial async-ness in here...
             return acc + name.count
         }
-        XCTAssertEqual(reduced, 9)
+        #expect(reduced == 9)
     }
     
-    func testAsyncReduceInto() async throws {
+    @Test
+    func asyncReduceInto() async throws {
         let names = ["Paul", "Lukas"]
         let reduced = try await names.reduce(into: 0) { acc, name in
             try await Task.sleep(for: .seconds(0.2)) // best i could think of to get some trivial async-ness in here...
             acc += name.count
         }
-        XCTAssertEqual(reduced, 9)
+        #expect(reduced == 9)
     }
 }


### PR DESCRIPTION
# add `Sequence.{flat,compact}MapIntoSet`

## :recycle: Current situation & Problem
This PR adds two `Sequence` extensions:
- `Sequence.compactMapIntoSet(_:)`
- `Sequence.flatMapIntoSet(_:)`

Both of these functions do exactly what the name suggests; they exist in order to achieve better performance when mapping a `Sequence` into a `Set`, since it allows us to skip the intermediate `Array` we'd have to work with when doing e.g. `Set(x.flatMap { ... })` instead of `x.flatMapIntoSet { ... }`.


## :gear: Release Notes
- added `Sequence.compactMapIntoSet(_:)` and `Sequence.flatMapIntoSet(_:)`

## :books: Documentation
the new functions are documented

## :white_check_mark: Testing
the new functions are tested

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
