### PR TITLE
Fix crash when using ArraySlice with DataDescriptor

### DIFF
--- a/Sources/SpeziFoundation/Misc/DataDescriptor.swift
+++ b/Sources/SpeziFoundation/Misc/DataDescriptor.swift
@@ -35,15 +35,17 @@ public struct DataDescriptor {
         self.init(data: data, mask: mask)
     }
 
-    private static func bitwiseAnd(lhs: Data, rhs: Data) -> Data {
+    private static func bitwiseAnd(lhs: Data, rhs: Data) -> [UInt8] {
         if rhs.count > lhs.count {
             return bitwiseAnd(lhs: rhs, rhs: lhs)
         }
 
-        var value = lhs
+        var value: [UInt8] = Array(repeating: 0, count: max(rhs.count, lhs.count))
+        var index = 0
 
-        for index in rhs.indices {
-            value[index] = lhs[index] & rhs[index]
+        for (lhsIndex, rhsIndex) in zip(lhs.indices, rhs.indices) {
+            value[index] = lhs[lhsIndex] & rhs[rhsIndex]
+            index += 1
         }
 
         return value
@@ -67,7 +69,7 @@ extension DataDescriptor: Sendable, Hashable {
     ///   - lhs: The left-hand-side.
     ///   - rhs: The right-hand-side.
     /// - Returns: Returns `true` if the bit pattern matches.
-    static func equalBitPattern(lhs: Data, rhs: Data) -> Bool {
+    static func equalBitPattern<D: Collection<UInt8>>(lhs: D, rhs: D) -> Bool {
         if rhs.count > lhs.count {
             return Self.equalBitPattern(lhs: rhs, rhs: lhs)
         }

--- a/Tests/SpeziFoundationTests/DataDescriptorTests.swift
+++ b/Tests/SpeziFoundationTests/DataDescriptorTests.swift
@@ -120,4 +120,13 @@ final class DataDescriptorTests: XCTestCase {
         XCTAssertTrue(descriptor1.matches(maskedData), "Descriptor with mask that ignores last bit should match data with last bit difference.")
         XCTAssertFalse(descriptor2.matches(maskedData), "Descriptor with fully applied mask should not match data with last bit difference.")
     }
+
+    func testMatches_ArraySlice() {
+        let data = Data([0x02, 0x04, 0x05])
+
+        let descriptor = DataDescriptor(data: Data([0xFF]), mask: Data([0b11001010]))
+
+        let suffix = data[2...]
+        XCTAssertFalse(descriptor.matches(suffix))
+    }
 }


### PR DESCRIPTION
# Fix crash when using ArraySlice with DataDescriptor

## :recycle: Current situation & Problem
When passing an array slice to the `DataDescriptor/matches(_:)` method, the method might crash while computing the bitwise and as the indices cannot between shared between the two arrays.


## :gear: Release Notes
* Fixed a crash that might occur in certain cases when using `DataDescriptor`.


## :books: Documentation
--


## :white_check_mark: Testing
Added regression test.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
