### PR TITLE
Support cancelable Child Tasks

### DIFF
--- a/Sources/SpeziFoundation/Concurrency/DiscardTaskGroup+CancellableTask.swift
+++ b/Sources/SpeziFoundation/Concurrency/DiscardTaskGroup+CancellableTask.swift
@@ -1,3 +1,12 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
 /// A handle to a child task that can be cancelled
 public struct CancelableTaskHandle: Sendable {
     @usableFromInline private(set) var continuation: AsyncStream<Void>.Continuation
@@ -17,7 +26,7 @@ public struct CancelableTaskHandle: Sendable {
 
 extension DiscardingTaskGroup {
     @usableFromInline
-    enum _CancelableState: Sendable {
+    enum _CancelableState: Sendable { // swiftlint:disable:this type_name
         case finished
         case canceled
     }

--- a/Sources/SpeziFoundation/Concurrency/DiscardTaskGroup+CancellableTask.swift
+++ b/Sources/SpeziFoundation/Concurrency/DiscardTaskGroup+CancellableTask.swift
@@ -1,0 +1,65 @@
+/// A handle to a child task that can be cancelled
+public struct CancelableTaskHandle: Sendable {
+    @usableFromInline private(set) var continuation: AsyncStream<Void>.Continuation
+
+    @inlinable
+    init(continuation: AsyncStream<Void>.Continuation) {
+        self.continuation = continuation
+    }
+
+    /// Cancel the child task.
+    @inlinable
+    public func cancel() {
+        self.continuation.finish()
+    }
+}
+
+
+extension DiscardingTaskGroup {
+    @usableFromInline
+    enum _CancelableState: Sendable {
+        case finished
+        case canceled
+    }
+    
+    /// Add a child task that is cancellable through the handle returned.
+    /// - Parameter operation: The child task to perform.
+    /// - Returns: Returns a task handle that can be used to cancel the task.
+    @inlinable
+    public mutating func addCancelableTask(_ operation: @Sendable @escaping () async -> Void) -> CancelableTaskHandle {
+        let signal = AsyncStream<Void>.makeStream()
+
+        self.addTask {
+            await withTaskGroup(of: _CancelableState.self) { group in
+                group.addTask {
+                    for await _ in signal.stream {}
+                    return .canceled
+                }
+
+                group.addTask {
+                    await operation()
+                    return .finished
+                }
+
+                guard let first = await group.next() else {
+                    fatalError("Child Task inconsistency.") // we spawned two tasks, something must be returned!
+                }
+
+                group.cancelAll() // either send the cancellation to the `operation` or make sure `stream` returns nil
+
+                guard let second = await group.next() else {
+                    fatalError("Child Task inconsistency.")
+                }
+
+                switch (first, second) {
+                case (.finished, .canceled), (.canceled, .finished):
+                    break
+                default:
+                    fatalError("Inconsistent state returned from child tasks: \(first), \(second).")
+                }
+            }
+        }
+
+        return CancelableTaskHandle(continuation: signal.continuation)
+    }
+}

--- a/Sources/SpeziFoundation/Concurrency/DiscardTaskGroup+CancellableTask.swift
+++ b/Sources/SpeziFoundation/Concurrency/DiscardTaskGroup+CancellableTask.swift
@@ -9,7 +9,7 @@
 
 /// A handle to a child task that can be cancelled
 public struct CancelableTaskHandle: Sendable {
-    @usableFromInline private(set) var continuation: AsyncStream<Void>.Continuation
+    @usableFromInline let continuation: AsyncStream<Void>.Continuation
 
     @inlinable
     init(continuation: AsyncStream<Void>.Continuation) {

--- a/Sources/SpeziFoundation/SpeziFoundation.docc/SpeziFoundation.md
+++ b/Sources/SpeziFoundation/SpeziFoundation.docc/SpeziFoundation.md
@@ -30,6 +30,8 @@ Spezi Foundation provides a base layer of functionality useful in many applicati
 - ``AsyncSemaphore``
 - ``ManagedAsynchronousAccess``
 - ``runOrScheduleOnMainActor(_:)``
+- ``CancelableTaskHandle``
+- ``_Concurrency/DiscardingTaskGroup/addCancelableTask(_:)``
 
 ### Encoders and Decoders
 - ``TopLevelEncoder``

--- a/Tests/SpeziFoundationTests/CancelableChildTaskTests.swift
+++ b/Tests/SpeziFoundationTests/CancelableChildTaskTests.swift
@@ -20,7 +20,7 @@ struct CancelableChildTaskTests {
                     confirmation()
                 }
 
-                try? await Task.sleep(for: .milliseconds(50), tolerance: .nanoseconds(0))
+                try? await Task.sleep(for: .milliseconds(100), tolerance: .nanoseconds(0))
                 handle.cancel()
             }
         }

--- a/Tests/SpeziFoundationTests/CancelableChildTaskTests.swift
+++ b/Tests/SpeziFoundationTests/CancelableChildTaskTests.swift
@@ -1,3 +1,11 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
 import SpeziFoundation
 import Testing
 

--- a/Tests/SpeziFoundationTests/CancelableChildTaskTests.swift
+++ b/Tests/SpeziFoundationTests/CancelableChildTaskTests.swift
@@ -1,0 +1,41 @@
+import SpeziFoundation
+import Testing
+
+@Suite("Cancelable Child Task")
+struct CancelableChildTaskTests {
+    @Test("Normal Completion")
+    func testNormalCompletion() async {
+        await withDiscardingTaskGroup { group in
+            await confirmation { confirmation in
+                let handle = group.addCancelableTask {
+                    try? await Task.sleep(for: .milliseconds(10), tolerance: .nanoseconds(0))
+                    confirmation()
+                }
+
+                try? await Task.sleep(for: .milliseconds(20), tolerance: .nanoseconds(0))
+                handle.cancel()
+            }
+        }
+    }
+
+    @Test("Cancelation")
+    func testCancelation() async {
+        await withDiscardingTaskGroup { group in
+            await confirmation { confirmation in
+                let handle = group.addCancelableTask {
+                    do {
+                        try await Task.sleep(for: .milliseconds(30), tolerance: .nanoseconds(0))
+                        Issue.record("Task was not cancelled!")
+                    } catch {
+                        confirmation()
+                    }
+                }
+
+                try? await Task.sleep(for: .milliseconds(5), tolerance: .nanoseconds(0))
+                handle.cancel()
+
+                try? await Task.sleep(for: .milliseconds(50), tolerance: .nanoseconds(0))
+            }
+        }
+    }
+}

--- a/Tests/SpeziFoundationTests/CancelableChildTaskTests.swift
+++ b/Tests/SpeziFoundationTests/CancelableChildTaskTests.swift
@@ -20,7 +20,7 @@ struct CancelableChildTaskTests {
                     confirmation()
                 }
 
-                try? await Task.sleep(for: .milliseconds(20), tolerance: .nanoseconds(0))
+                try? await Task.sleep(for: .milliseconds(50), tolerance: .nanoseconds(0))
                 handle.cancel()
             }
         }


### PR DESCRIPTION
# Support cancelable Child Tasks

## :recycle: Current situation & Problem
In certain cases when working with task groups, it is helpful to have control over child task cancellation. This PR adds a helper method to easily construct such cancelable child tasks.


## :gear: Release Notes
* Add `DiscardingTaskGroup/addCancelableTask(_:)`


## :books: Documentation
Added to DocC catalog.


## :white_check_mark: Testing
Two new unit tests that confirm the not cancelled and cancelled case.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
