### PR TITLE
Deprecate runOrScheduleOnMainActor(_:)

### DIFF
--- a/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
+++ b/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
@@ -10,8 +10,12 @@ import Foundation
 
 
 /// Runs or schedules a closure on the `MainActor`, depending on the current execution context.
+///
 /// If the function is already running on the `MainActor`, the closure will be invoked immediately.
 /// Otherwise, an invocation of the closure will be scheduled onto the `MainActor`.
+///
+/// - Important: Do not use this method as it breaks structured concurrency. Instead you might choose to use a combination of the `task(_:)` modifier and an `AsyncStream` to schedule work
+///     onto the MainActor. If working within Spezi Modules, explore the `ServiceModule` protocol to add structured concurrency support to your Module.
 @available(*, deprecated, message: "Please do not use this method as it breaks structured concurrency. Consider using other mechanisms like .task(_:).")
 public func runOrScheduleOnMainActor(
     _ block: @MainActor @escaping () -> Void

--- a/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
+++ b/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
@@ -16,7 +16,9 @@ import Foundation
 ///
 /// - Important: Do not use this method as it breaks structured concurrency. Instead you might choose to use a combination of the `task(_:)` modifier and an `AsyncStream` to schedule work
 ///     onto the MainActor. If working within Spezi Modules, explore the `ServiceModule` protocol to add structured concurrency support to your Module.
-@available(*, deprecated, message: "Please do not use this method as it breaks structured concurrency. Consider using other mechanisms like .task(_:).")
+@available(
+    *, deprecated, message: "Do not use this method as it breaks structured concurrency. Consider using other mechanisms like an AsyncStream."
+)
 public func runOrScheduleOnMainActor(
     _ block: @MainActor @escaping () -> Void
 ) {

--- a/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
+++ b/Sources/SpeziFoundation/Concurrency/MainActorExecution.swift
@@ -12,6 +12,7 @@ import Foundation
 /// Runs or schedules a closure on the `MainActor`, depending on the current execution context.
 /// If the function is already running on the `MainActor`, the closure will be invoked immediately.
 /// Otherwise, an invocation of the closure will be scheduled onto the `MainActor`.
+@available(*, deprecated, message: "Please do not use this method as it breaks structured concurrency. Consider using other mechanisms like .task(_:).")
 public func runOrScheduleOnMainActor(
     _ block: @MainActor @escaping () -> Void
 ) {


### PR DESCRIPTION
# Deprecate `runOrScheduleOnMainActor(_:)`

## :recycle: Current situation & Problem
The function `runOrScheduleOnMainActor` breaks structured concurrency and is therefore getting deprecated.
Callers should instead use different methods that preserve structured concurrency, like a combination of the `.task` modifier and an `AsyncStream`. The new `ServiceModule` feature in Spezi might also come in handy.

## :gear: Release Notes
* Deprecate `runOrScheduleOnMainActor(_:)`


## :books: Documentation
Updated docs.


## :white_check_mark: Testing
N/A

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
