### PR TITLE
move some APIs into SpeziFoundation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,3 +19,8 @@ jobs:
   swiftlint:
     name: SwiftLint
     uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2
+  breaking_changes:
+    name: Diagnose Breaking Changes
+    uses: StanfordSpezi/.github/.github/workflows/breaking-changes.yml@v2
+    with:
+      runsonlabels: '["macOS", "self-hosted"]'

--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,7 @@ let package = Package(
             resources: [
                 .process("Resources")
             ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -54,6 +55,7 @@ let package = Package(
                 .product(name: "RuntimeAssertionsTesting", package: "XCTRuntimeAssertions"),
                 .product(name: "XCTRuntimeAssertions", package: "XCTRuntimeAssertions")
             ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         )
     ]

--- a/Sources/SpeziFoundation/Collection Builders/ArrayBuilder.swift
+++ b/Sources/SpeziFoundation/Collection Builders/ArrayBuilder.swift
@@ -13,7 +13,7 @@ public typealias ArrayBuilder<T> = RangeReplaceableCollectionBuilder<[T]>
 extension Array {
     /// Constructs a new array, using a result builder.
     @inlinable
-    public init(@ArrayBuilder<Element> build: () -> Self) {
-        self = build()
+    public init<E>(@ArrayBuilder<Element> build: () throws(E) -> Self) throws(E) {
+        self = try build()
     }
 }

--- a/Sources/SpeziFoundation/Compression/CompressionAlgorithm.swift
+++ b/Sources/SpeziFoundation/Compression/CompressionAlgorithm.swift
@@ -1,0 +1,36 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+/// A compression algorithm
+public protocol CompressionAlgorithm {
+    /// An error that can occur when compressing an input
+    associatedtype CompressionError: Swift.Error
+    /// An error that can occur when decompressing an input
+    associatedtype DecompressionError: Swift.Error
+    
+    /// Compresses the input.
+    static func compress(_ input: borrowing some Collection<UInt8>) throws(CompressionError) -> Data
+    /// Decompresses the input.
+    static func decompress(_ input: borrowing some Collection<UInt8>) throws(DecompressionError) -> Data
+}
+
+
+extension Collection<UInt8> {
+    /// Compresses the sequence of bytes using the specified ``CompressionAlgorithm``
+    public func compressed<Algorithm: CompressionAlgorithm>(using algorithm: Algorithm.Type) throws(Algorithm.CompressionError) -> Data {
+        try algorithm.compress(self)
+    }
+    
+    /// Decompresses the sequence of bytes using the specified ``CompressionAlgorithm``
+    public func decompressed<Algorithm: CompressionAlgorithm>(using algorithm: Algorithm.Type) throws(Algorithm.DecompressionError) -> Data {
+        try algorithm.decompress(self)
+    }
+}

--- a/Sources/SpeziFoundation/Compression/Zlib.swift
+++ b/Sources/SpeziFoundation/Compression/Zlib.swift
@@ -1,0 +1,104 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import zlib
+
+
+/// A wrapper around the `zlib` compression library
+public enum Zlib: CompressionAlgorithm {
+    public typealias DecompressionError = CompressionError
+    
+    public enum CompressionError: Error {
+        case invalidInput
+        case notEnoughMemory
+        case other(Int32)
+    }
+    
+    public static func compress(_ input: borrowing some Collection<UInt8>) throws(CompressionError) -> Data {
+        let inputCount = input.count
+        let result: Result<Data, CompressionError>? = input.withContiguousStorageIfAvailable { inputBuffer in
+            precondition(inputBuffer.count == inputCount)
+            guard let inputBufferPtr = inputBuffer.baseAddress else {
+                return .failure(.invalidInput)
+            }
+            let outputBufferSize = compressBound(UInt(inputBuffer.count))
+            let outputBuffer: UnsafeMutablePointer<UInt8> = .allocate(capacity: Int(outputBufferSize))
+            var compressedSize: UInt = outputBufferSize
+            let status = zlib.compress2(outputBuffer, &compressedSize, inputBufferPtr, UInt(inputBuffer.count), 9)
+            switch status {
+            case Z_OK:
+                return .success(Data(bytesNoCopy: outputBuffer, count: Int(compressedSize), deallocator: .free))
+            case Z_MEM_ERROR:
+                outputBuffer.deallocate()
+                return .failure(.notEnoughMemory)
+            case Z_BUF_ERROR:
+                // shouldn't happen, since we use compressBound() to determine the expected output buffer size...
+                fallthrough // swiftlint:disable:this no_fallthrough_only
+            case Z_STREAM_ERROR:
+                // should be unreachable, since we only ever pass valid levels (ie, 0-9) into compress2...
+                fallthrough // swiftlint:disable:this no_fallthrough_only
+            default:
+                // should also be unreachable, since the switch above covers all status codes mentioned in the zlib documentation.
+                outputBuffer.deallocate()
+                return .failure(.other(status))
+            }
+        }
+        if let result {
+            return try result.get()
+        } else {
+            throw .invalidInput
+        }
+    }
+    
+    
+    public static func decompress(_ input: borrowing some Collection<UInt8>) throws(DecompressionError) -> Data {
+        try decompress(input, expectedOutputLength: input.count)
+    }
+    
+    private static func decompress(_ input: borrowing some Collection<UInt8>, expectedOutputLength: Int) throws(DecompressionError) -> Data {
+        let inputCount = input.count
+        let result: Result<Data, CompressionError>? = input.withContiguousStorageIfAvailable { inputBuffer in
+            precondition(inputBuffer.count == inputCount)
+            guard let inputBufferPtr = inputBuffer.baseAddress else {
+                return .failure(.invalidInput)
+            }
+            let outputBufferSize = UInt(expectedOutputLength)
+            let outputBuffer: UnsafeMutablePointer<UInt8> = .allocate(capacity: Int(outputBufferSize))
+            var decompressedSize: UInt = outputBufferSize
+            let status = zlib.uncompress(outputBuffer, &decompressedSize, inputBufferPtr, UInt(inputBuffer.count))
+            switch status {
+            case Z_OK:
+                return .success(Data(bytesNoCopy: outputBuffer, count: Int(decompressedSize), deallocator: .free))
+            case Z_MEM_ERROR:
+                outputBuffer.deallocate()
+                return .failure(.notEnoughMemory)
+            case Z_BUF_ERROR:
+                // if we end up in here, out output buffer was too small.
+                fallthrough // swiftlint:disable:this no_fallthrough_only
+            case Z_STREAM_ERROR:
+                // should be unreachable, since we only ever pass valid levels (ie, 0-9) into compress2...
+                fallthrough // swiftlint:disable:this no_fallthrough_only
+            default:
+                // should also be unreachable, since the switch above covers all status codes mentioned in the zlib documentation.
+                outputBuffer.deallocate()
+                return .failure(.other(status))
+            }
+        }
+        guard let result else {
+            throw .invalidInput
+        }
+        do {
+            return try result.get()
+        } catch DecompressionError.other(Z_BUF_ERROR) {
+            return try Self.decompress(input, expectedOutputLength: expectedOutputLength + (expectedOutputLength / 2))
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/SpeziFoundation/Concurrency/AsyncSemaphore.swift
+++ b/Sources/SpeziFoundation/Concurrency/AsyncSemaphore.swift
@@ -52,7 +52,7 @@ import Foundation
 /// - Warning: `cancelAll` will trigger a runtime error if it attempts to cancel tasks that are not cancellable.
 public final class AsyncSemaphore: Sendable {
     private enum Suspension {
-        case cancelable(UnsafeContinuation<Void, Error>)
+        case cancelable(UnsafeContinuation<Void, any Error>)
         case regular(UnsafeContinuation<Void, Never>)
 
         

--- a/Sources/SpeziFoundation/Concurrency/ManagedAsynchronousAccess.swift
+++ b/Sources/SpeziFoundation/Concurrency/ManagedAsynchronousAccess.swift
@@ -82,7 +82,7 @@ extension ManagedAsynchronousAccess where Value == Void {
 }
 
 
-extension ManagedAsynchronousAccess where E == Error {
+extension ManagedAsynchronousAccess where E == any Error {
     /// Perform an managed, asynchronous access.
     ///
     /// Call this method to perform an managed, asynchronous access. This method awaits exclusive access, creates a continuation and

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Metadata.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Metadata.swift
@@ -16,12 +16,20 @@ extension MarkdownDocument {
         
         private let storage: Storage
         
+        /// Creates a new, empty `Metadata` object.
         public init() {
             storage = .init()
         }
         
+        /// Creates a `Metadata` object from the specified key-value pairs
         public init(_ values: [String: String]) {
             self.storage = values
+        }
+        
+        /// Parses only  the frontmatter of a Markdown `String`.
+        public init(parsing markdown: String) throws(ParseError) {
+            var parser = Parser(input: markdown, customElementNames: [])
+            self.init(try parser.parseFrontmatter())
         }
         
         /// Fetches the metadata value associated with the specified key.

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Metadata.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Metadata.swift
@@ -1,0 +1,82 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension MarkdownDocument {
+    /// A key-value mapping containing the metadata parsed from a consent form.
+    public struct Metadata: Hashable, Sendable {
+        public typealias Storage = [String: String]
+        
+        private let storage: Storage
+        
+        public init() {
+            storage = .init()
+        }
+        
+        public init(_ values: [String: String]) {
+            self.storage = values
+        }
+        
+        /// Fetches the metadata value associated with the specified key.
+        public subscript(key: String) -> String? {
+            storage[key]
+        }
+    }
+}
+
+
+extension MarkdownDocument.Metadata {
+    /// The document's title, if present in the metadata
+    public var title: String? {
+        self["title"]
+    }
+    
+    /// The document's version, if present in the metadata
+    public var version: Version? {
+        self["version"].flatMap { Version($0) }
+    }
+}
+
+
+extension MarkdownDocument.Metadata: Collection {
+    public var startIndex: Storage.Index {
+        storage.startIndex
+    }
+    
+    public var endIndex: Storage.Index {
+        storage.endIndex
+    }
+    
+    public func index(after idx: Storage.Index) -> Storage.Index {
+        storage.index(after: idx)
+    }
+    
+    public subscript(position: Storage.Index) -> Storage.Element  {
+        storage[position]
+    }
+}
+
+
+extension MarkdownDocument.Metadata: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, String)...) {
+        self.init(Dictionary(uniqueKeysWithValues: elements))
+    }
+}
+
+
+extension MarkdownDocument.Metadata: Codable {
+    public init(from decoder: any Decoder) throws {
+        storage = try Storage(from: decoder)
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        try storage.encode(to: encoder)
+    }
+}

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Parser.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Parser.swift
@@ -76,7 +76,7 @@ extension MarkdownDocument {
     }
 }
 
-    
+
 extension MarkdownDocument.Parser {
     consuming func parse() throws(ParseError) -> MarkdownDocument { // swiftlint:disable:this function_body_length cyclomatic_complexity
         typealias Block = MarkdownDocument.Block

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Parser.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Parser.swift
@@ -138,7 +138,7 @@ extension MarkdownDocument.Parser {
     }
     
     
-    private mutating func parseFrontmatter() throws(ParseError) -> [String: String] {
+    mutating func parseFrontmatter() throws(ParseError) -> [String: String] {
         guard currentLine == "---" else {
             return [:]
         }

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
@@ -58,6 +58,7 @@ extension MarkdownDocument {
         public internal(set) var raw: String
         
         /// Reads the value of the first attribute with the specified name, if available.
+        @inlinable
         public subscript(attribute name: String) -> String? {
             attributes.first { $0.name == name }?.value
         }

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
@@ -10,28 +10,54 @@ import Foundation
 
 
 extension MarkdownDocument {
+    /// A unit of content within a ``MarkdownDocument``.
     public enum Block: Hashable, Sendable {
-        case markdown(String)
-        case customElement(ParsedCustomElement)
+        /// A block of Markdown text
+        case markdown(id: String?, rawContents: String)
+        /// A parsed custom element.
+        case customElement(CustomElement)
+        
+        /// The block's stable identifier, if available.
+        public var id: String? {
+            switch self {
+            case .markdown(let id, _):
+                id
+            case .customElement(let element):
+                element[attribute: "id"]
+            }
+        }
     }
     
-    public struct ParsedCustomElement: Hashable, Sendable {
+    /// A custom element that was parsed from a Markdown string.
+    public struct CustomElement: Hashable, Sendable {
+        /// The element's content
         public indirect enum Content: Hashable, Sendable {
+            /// A piece of plain-text content
             case text(String)
-            case element(ParsedCustomElement)
+            /// Another element.
+            case element(CustomElement)
         }
         
+        /// An attribute within a parsed element.
+        ///
+        /// Attributes are modeled after HTML attributes, and are simple key-value pairs of the form `name=value`.
         public struct ParsedAttribute: Hashable, Sendable {
+            /// The attribute's name
             public let name: String
+            /// The attribute's value
             public let value: String
         }
         
+        /// The element name.
         public internal(set) var name: String
+        /// The element's attributes.
         public internal(set) var attributes: [ParsedAttribute] = []
+        /// The element's content.
         public internal(set) var content: [Content] = []
         /// The unprocessed raw text from which this element was parsed.
         public internal(set) var raw: String
         
+        /// Reads the value of the first attribute with the specified name, if available.
         public subscript(attribute name: String) -> String? {
             attributes.first { $0.name == name }?.value
         }

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
@@ -1,0 +1,37 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension MarkdownDocument {
+    public enum Block: Hashable, Sendable {
+        case markdown(String)
+        case customElement(ParsedCustomElement)
+    }
+    
+    public struct ParsedCustomElement: Hashable, Sendable {
+        public indirect enum Content: Hashable, Sendable {
+            case text(String)
+            case element(ParsedCustomElement)
+        }
+        
+        public struct ParsedAttribute: Hashable, Sendable {
+            public let name: String
+            public let value: String
+        }
+        
+        public internal(set) var name: String
+        public internal(set) var attributes: [ParsedAttribute] = []
+        public internal(set) var content: [Content] = []
+        
+        public subscript(attribute name: String) -> String? {
+            attributes.first { $0.name == name }?.value
+        }
+    }
+}

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
@@ -29,6 +29,8 @@ extension MarkdownDocument {
         public internal(set) var name: String
         public internal(set) var attributes: [ParsedAttribute] = []
         public internal(set) var content: [Content] = []
+        /// The unprocessed raw text from which this element was parsed.
+        public internal(set) var raw: String
         
         public subscript(attribute name: String) -> String? {
             attributes.first { $0.name == name }?.value

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
@@ -15,9 +15,9 @@ import Foundation
 ///
 /// ### Initializers
 /// - ``init(metadata:blocks:)``
-/// - ``init(processing:)-(String)``
-/// - ``init(processing:)-(Data)``
-/// - ``init(processingContentsOf:)``
+/// - ``init(processing:customElementNames:)-(String,Set<String>)``
+/// - ``init(processing:customElementNames:)-(Data,Set<String>)``
+/// - ``init(processingContentsOf:customElementNames:)``
 /// - ``ParseError``
 ///
 /// ### Instance Properties
@@ -39,19 +39,22 @@ public struct MarkdownDocument: Hashable, Sendable {
         self.blocks = blocks
     }
     
-    public init(processing text: String) throws(ParseError) {
-        let parser = MarkdownDocumentParser(input: text)
+    public init(processing text: String, customElementNames: Set<String> = []) throws(ParseError) {
+        let parser = Parser(input: text, customElementNames: customElementNames)
         self = try parser.parse()
     }
     
-    public init(processing data: Data) throws(ParseError) {
+    public init(processing data: Data, customElementNames: Set<String> = []) throws(ParseError) {
         guard let text = String(data: data, encoding: .utf8) else {
             throw ParseError(kind: .nonUTF8Input, sourceLoc: .zero)
         }
-        try self.init(processing: text)
+        try self.init(processing: text, customElementNames: customElementNames)
     }
     
-    public init(processingContentsOf url: URL) throws {
-        try self.init(processing: Data(contentsOf: url))
+    public init(processingContentsOf url: URL, customElementNames: Set<String> = []) throws {
+        try self.init(
+            processing: Data(contentsOf: url),
+            customElementNames: customElementNames
+        )
     }
 }

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
@@ -1,0 +1,57 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+/// A Markdown document
+///
+/// ## Topics
+///
+/// ### Initializers
+/// - ``init(metadata:blocks:)``
+/// - ``init(processing:)-(String)``
+/// - ``init(processing:)-(Data)``
+/// - ``init(processingContentsOf:)``
+/// - ``ParseError``
+///
+/// ### Instance Properties
+/// - ``metadata``
+/// - ``blocks``
+///
+/// ### Supporting Types
+/// - ``Metadata``
+/// - ``Block``
+public struct MarkdownDocument: Hashable, Sendable {
+    /// The document's metadata.
+    public var metadata: Metadata
+    /// The document's content blocks.
+    public var blocks: [Block]
+    
+    /// Creates a new Markdown document.
+    public init(metadata: Metadata, blocks: [Block]) {
+        self.metadata = metadata
+        self.blocks = blocks
+    }
+    
+    public init(processing text: String) throws(ParseError) {
+        let parser = MarkdownDocumentParser(input: text)
+        self = try parser.parse()
+    }
+    
+    public init(processing data: Data) throws(ParseError) {
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw ParseError(kind: .nonUTF8Input, sourceLoc: .zero)
+        }
+        try self.init(processing: text)
+    }
+    
+    public init(processingContentsOf url: URL) throws {
+        try self.init(processing: Data(contentsOf: url))
+    }
+}

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
@@ -39,11 +39,27 @@ public struct MarkdownDocument: Hashable, Sendable {
         self.blocks = blocks
     }
     
+    /// Creates a new Markdown document by processing a `String`.
+    ///
+    /// Note that thie doesn't perform any Markdown parsing on its own; rather, it splits up a markdown file into a sequence of blocks,
+    /// each of which is either markdown content or a custom HTML element.
+    ///
+    /// - parameter text: The Markdown string to process.
+    /// - parameter customElementNames: A `Set` of HTML tag names which should be processed into custom elements.
+    ///     Any HTML tags encountered that aren't specified in the set will be treated as if they were part of the normal markdown text.
     public init(processing text: String, customElementNames: Set<String> = []) throws(ParseError) {
         let parser = Parser(input: text, customElementNames: customElementNames)
         self = try parser.parse()
     }
     
+    /// Creates a new Markdown document by processing a `Data` object.
+    ///
+    /// Note that thie doesn't perform any Markdown parsing on its own; rather, it splits up a markdown file into a sequence of blocks,
+    /// each of which is either markdown content or a custom HTML element.
+    ///
+    /// - parameter data: The Markdown data to process.
+    /// - parameter customElementNames: A `Set` of HTML tag names which should be processed into custom elements.
+    ///     Any HTML tags encountered that aren't specified in the set will be treated as if they were part of the normal markdown text.
     public init(processing data: Data, customElementNames: Set<String> = []) throws(ParseError) {
         guard let text = String(data: data, encoding: .utf8) else {
             throw ParseError(kind: .nonUTF8Input, sourceLoc: .zero)
@@ -51,6 +67,14 @@ public struct MarkdownDocument: Hashable, Sendable {
         try self.init(processing: text, customElementNames: customElementNames)
     }
     
+    /// Creates a new Markdown document by processing the contents of a file.
+    ///
+    /// Note that thie doesn't perform any Markdown parsing on its own; rather, it splits up a markdown file into a sequence of blocks,
+    /// each of which is either markdown content or a custom HTML element.
+    ///
+    /// - parameter url: The URL of the markdown file to process.
+    /// - parameter customElementNames: A `Set` of HTML tag names which should be processed into custom elements.
+    ///     Any HTML tags encountered that aren't specified in the set will be treated as if they were part of the normal markdown text.
     public init(processingContentsOf url: URL, customElementNames: Set<String> = []) throws {
         try self.init(
             processing: Data(contentsOf: url),

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocumentParser.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocumentParser.swift
@@ -1,0 +1,432 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension MarkdownDocument { // swiftlint:disable:this file_types_order
+    /// An error that occurred when parsing markdown text.
+    public struct ParseError: Error, Hashable {
+        /// The parse error's kind
+        public enum Kind: Hashable, Sendable {
+            /// The parse input wasn't encoded as valid UTF-8 text.
+            case nonUTF8Input
+            /// The parser reached the end of the input file, even though it may have been expecting further content.
+            case eof
+            /// The parser ran into an unexpected character
+            case unexpectedCharacter
+            /// Some other issue.
+            case other(String)
+        }
+        
+        /// A location within a markdown document, expressed as a line and column number.
+        public struct SourceLocation: Hashable, Comparable, Sendable {
+            static let zero = Self(line: 0, column: 0)
+            
+            /// The location's line number, starting at 0.
+            public let line: UInt
+            /// The location's column number, i.e., its offset within its line, starting at 0.
+            public let column: UInt
+            
+            fileprivate init(line: UInt, column: UInt) {
+                self.line = line
+                self.column = column
+            }
+            
+            public static func < (lhs: Self, rhs: Self) -> Bool {
+                if lhs.line < rhs.line {
+                    true
+                } else if lhs.line == rhs.line {
+                    lhs.column < rhs.column
+                } else {
+                    false
+                }
+            }
+        }
+        
+        /// The specific kind of error
+        public let kind: Kind
+        /// The source location at which the error occurred
+        public let sourceLoc: SourceLocation
+    }
+}
+
+
+struct MarkdownDocumentParser: ~Copyable {
+    typealias ParseError = MarkdownDocument.ParseError
+    typealias ParsedCustomElement = MarkdownDocument.ParsedCustomElement
+    
+    private let input: String
+    private var position: String.Index
+    
+    init(input: String) {
+        self.input = input
+        self.position = input.startIndex
+    }
+    
+    
+    consuming func parse() throws(ParseError) -> MarkdownDocument {
+        typealias Block = MarkdownDocument.Block
+        let frontmatter = try parseFrontmatter()
+        var blocks: [Block] = []
+        var currentBlockText = ""
+        do {
+            while let currentChar {
+                if currentChar == "<", isAtBeginningOfLine,
+                   let element = try parseCustomElement() {
+                    blocks.append(.markdown(currentBlockText))
+                    currentBlockText.removeAll(keepingCapacity: true)
+                    blocks.append(.customElement(element))
+                } else if try skipCommentIfApplicable() {
+                    // we ignore the comment
+                } else {
+                    currentBlockText.append(currentChar)
+                    consume()
+                }
+            }
+        } catch {
+            switch error.kind {
+            case .eof:
+                break
+            default:
+                throw error
+            }
+        }
+        blocks.append(.markdown(currentBlockText))
+        blocks = blocks.compactMap { block -> Block? in
+            switch block {
+            case .markdown(let text):
+                let trimmed = text.trimmingWhitespace()
+                if trimmed.isEmpty {
+                    return nil
+                } else {
+                    return .markdown(String(trimmed))
+                }
+            case .customElement:
+                return block
+            }
+        }
+        return .init(metadata: .init(frontmatter), blocks: blocks)
+    }
+    
+    
+    private mutating func parseFrontmatter() throws(ParseError) -> [String: String] {
+        guard currentLine == "---" else {
+            return [:]
+        }
+        var frontmatter: [String: String] = [:]
+        consumeLine()
+        while let key = try? parseIdentifier() {
+            try expectAndConsume(":")
+            consume(while: { $0.isWhitespace && !$0.isNewline })
+            let value = currentLine ?? ""
+            consumeLine()
+            frontmatter[key] = String(value)
+        }
+        guard currentLine == "---" else {
+            try emitError(.other("Unable to find end of frontmatter"))
+        }
+        consumeLine()
+        return frontmatter
+    }
+    
+    
+    private mutating func parseIdentifier() throws(ParseError) -> String {
+        var identifier = ""
+        if let currentChar, currentChar.isValidIdentStart {
+            identifier.append(currentChar)
+            consume()
+        } else {
+            try emitError(.unexpectedCharacter)
+        }
+        while let currentChar, currentChar.isValidIdent {
+            identifier.append(currentChar)
+            consume()
+        }
+        return identifier
+    }
+    
+    private mutating func parseInteger() -> Int? {
+        let initialPos = position
+        var value = 0
+        let negative: Bool
+        if let currentChar, currentChar == "-" {
+            negative = true
+            consume()
+        } else {
+            negative = false
+        }
+        let posFirstPotentialDigit = position
+        while let currentChar, currentChar.isASCII, let digit = currentChar.wholeNumberValue {
+            value *= 10
+            value += digit
+            consume()
+        }
+        if position == posFirstPotentialDigit {
+            // if we weren't able to read any digits, we restore the initial position and return nil
+            position = initialPos
+            return nil
+        } else {
+            // otherwise, we were able to parse a value, and will return that.
+            return value * (negative ? -1 : 1)
+        }
+    }
+    
+    
+    private mutating func parseAttrValue() throws(ParseError) -> String {
+        if currentChar == "\"" {
+            try parseStringLiteral()
+        } else if let ident = try? parseIdentifier() {
+            ident
+        } else if let value = parseInteger() {
+            String(value)
+        } else {
+            ""
+        }
+    }
+    
+    
+    private mutating func parseStringLiteral() throws(ParseError) -> String {
+        try expectAndConsume("\"")
+        var text = ""
+        while true {
+            guard let currentChar else {
+                try emitError(.eof)
+            }
+            let isEscaped = !text.suffix { $0 == #"\"# }.count.isMultiple(of: 2)
+            if currentChar == "\"" && !isEscaped {
+                break
+            }
+            consume()
+            text.append(currentChar)
+        }
+        try expectAndConsume("\"")
+        return text
+    }
+    
+    
+    private mutating func parseCustomElement() throws(ParseError) -> ParsedCustomElement? {
+        // swiftlint:disable:previous function_body_length cyclomatic_complexity
+        consume(while: \.isWhitespace)
+        guard currentChar == "<", let next = peek(), next.isValidIdentStart else {
+            return nil
+        }
+        try expectAndConsume("<")
+        let name = try parseIdentifier()
+        var parsedElement = ParsedCustomElement(name: name)
+        var elementIsClosed = false
+        loop: while true {
+            switch currentChar {
+            case .none:
+                break loop
+            case ">":
+                // end of opening tag
+                consume()
+                break loop
+            case "/" where peek() == ">":
+                // upcoming end of opening tag
+                consume(2)
+                elementIsClosed = true
+                break loop
+            case .some(let char) where char.isWhitespace:
+                // whitespace/newlines between things
+                consume()
+            case .some:
+                let attrName = try parseIdentifier()
+                let attrValue: String
+                if currentChar == "=" {
+                    consume()
+                    attrValue = try parseAttrValue()
+                } else {
+                    // attr w/out a value
+                    attrValue = ""
+                }
+                parsedElement.attributes.append(.init(name: attrName, value: attrValue))
+            }
+        }
+        if elementIsClosed {
+            return parsedElement
+        }
+        if let element = _attemptToCloseCustomElement(parsedElement) {
+            return element
+        } else {
+            while true {
+                if let element = try parseCustomElement() {
+                    parsedElement.content.append(.element(element))
+                } else {
+                    let text = String(parseElementTextContents().trimmingWhitespace())
+                    if !text.isEmpty {
+                        parsedElement.content.append(.text(text))
+                    } else {
+                        // unable to parse an element, but also no text-only content in there...
+                        if let element = _attemptToCloseCustomElement(parsedElement) {
+                            consume(while: \.isWhitespace)
+                            return element
+                        } else {
+                            try emitError(.other("unable to close \(name)"))
+                        }
+                    }
+                }
+            }
+        }
+        try emitError(.other("Unable to find closing tag for \(parsedElement)"))
+    }
+    
+    private mutating func _attemptToCloseCustomElement(_ element: ParsedCustomElement) -> ParsedCustomElement? {
+        let possibleClosingTags = ["</>", "</\(element.name)>"]
+        for tag in possibleClosingTags {
+            if remainingInput.starts(with: tag) { // swiftlint:disable:this for_where
+                consume(tag.count)
+                return element
+            }
+        }
+        return nil
+    }
+    
+    
+    /// Parses the `{X}` part in `<element>{X}</element>`.
+    private mutating func parseElementTextContents() -> String {
+        var text = ""
+        while let currentChar, currentChar != "<" {
+            text.append(currentChar)
+            consume()
+        }
+        return String(text.trimmingWhitespace())
+    }
+    
+    
+    /// Parses an HTML comment starting at the current position.
+    ///
+    /// Since HTML doesn't support nested comments, this function in effect simply consumes all text until the next `-->` character sequence.
+    ///
+    /// - returns: the contents of the parsed comment, excluding the leading `<!--` and the trailing `-->`.
+    ///     if no comment starts at the current position, the function returns `nil`.
+    private mutating func parseComment() throws(ParseError) -> String? {
+        guard remainingInput.starts(with: "<!--") else {
+            return nil
+        }
+        consume(4)
+        var commentBody = ""
+        while let currentChar {
+            if remainingInput.starts(with: "-->") {
+                consume(3)
+                return commentBody
+            } else {
+                commentBody.append(currentChar)
+                consume()
+            }
+        }
+        // we ran out of characters before closing the comment.
+        try emitError(.other("Unterminated Comment"))
+    }
+    
+    
+    /// Skips a comment, if one starts at the current position
+    ///
+    /// - returns: `true` iff a comment was skipped, `false` otherwise.
+    @discardableResult
+    private mutating func skipCommentIfApplicable() throws(ParseError) -> Bool {
+        try parseComment() != nil
+    }
+}
+
+extension MarkdownDocumentParser {
+    private func emitError(_ kind: ParseError.Kind) throws(ParseError) -> Never {
+        throw .init(kind: kind, sourceLoc: currentSourceLoc)
+    }
+}
+
+
+extension MarkdownDocumentParser {
+    private var currentChar: Character? {
+        input[safe: position]
+    }
+    
+    private var remainingInput: Substring {
+        input[position...]
+    }
+    
+    private var currentLine: Substring? {
+        remainingInput.isEmpty ? nil : remainingInput.prefix { !$0.isNewline }
+    }
+    
+    private var isAtBeginningOfLine: Bool {
+        position == input.startIndex && position < input.endIndex || input[input.index(before: position)].isNewline
+    }
+    
+    private func peek(_ offset: Int = 1) -> Character? {
+        input[safe: input.index(position, offsetBy: offset)]
+    }
+    
+    private mutating func consume(_ count: Int = 1) {
+        guard count > 0 else { // swiftlint:disable:this empty_count
+            return
+        }
+        let newIndex = input.index(position, offsetBy: count)
+        position = min(input.endIndex, newIndex)
+    }
+    
+    private mutating func consume(while predicate: (Character) -> Bool) {
+        while let currentChar, predicate(currentChar) {
+            consume()
+        }
+    }
+    
+    private mutating func expectAndConsume(_ char: Character) throws(ParseError) {
+        guard currentChar == char else {
+            try emitError(.unexpectedCharacter)
+        }
+        consume()
+    }
+    
+    /// Consumes all upcoming characters up to (and including) the next newline character.
+    private mutating func consumeLine() {
+        while let currentChar, !currentChar.isNewline {
+            consume()
+        }
+        if currentChar?.isNewline == true {
+            consume()
+        }
+    }
+}
+
+
+extension MarkdownDocumentParser {
+    private var currentSourceLoc: ParseError.SourceLocation {
+        let lineNumber = input[..<position].count(where: \.isNewline)
+        let wholeCurrentLine = { () -> Substring in
+            let startIdx = input[..<position].lastIndex(where: \.isNewline).map { input.index(after: $0) }
+            let endIdx = remainingInput.firstIndex(where: \.isNewline)
+            return switch (startIdx, endIdx) {
+            case (nil, nil):
+                input[...]
+            case let (.some(startIdx), .none):
+                input[startIdx...]
+            case let (.none, .some(endIdx)):
+                input[...endIdx]
+            case let (.some(startIdx), .some(endIdx)):
+                input[startIdx...endIdx]
+            }
+        }()
+        return .init(
+            line: UInt(lineNumber),
+            column: UInt(wholeCurrentLine.distance(from: wholeCurrentLine.startIndex, to: position))
+        )
+    }
+}
+
+
+extension Character {
+    fileprivate var isValidIdentStart: Bool {
+        (self >= "a" && self <= "z") || (self >= "A" && self <= "Z") || self == "_"
+    }
+    
+    fileprivate var isValidIdent: Bool {
+        isValidIdentStart || (self >= "0" && self <= "9") || self == "-"
+    }
+}

--- a/Sources/SpeziFoundation/Misc/Calendar.swift
+++ b/Sources/SpeziFoundation/Misc/Calendar.swift
@@ -352,3 +352,15 @@ extension TimeZone {
         return transitions
     }
 }
+
+
+// MARK: Time Zones
+
+extension TimeZone {
+    // swiftlint:disable force_unwrapping
+    /// The time zone for LA.
+    public static let losAngeles = TimeZone(identifier: "America/Los_Angeles")!
+    /// The time zone for Berlin.
+    public static let berlin = TimeZone(identifier: "Europe/Berlin")!
+    // swiftlint:enable force_unwrapping
+}

--- a/Sources/SpeziFoundation/Misc/FileManager.swift
+++ b/Sources/SpeziFoundation/Misc/FileManager.swift
@@ -35,6 +35,15 @@ extension FileManager {
     }
     
     
+    /// Retrieves the contents of the directory at the specified url.
+    public func contents(
+        of dirUrl: URL,
+        includingPropertiesForKeys: [URLResourceKey]? = nil, // swiftlint:disable:this discouraged_optional_collection
+        options: DirectoryEnumerationOptions = []
+    ) throws -> [URL] {
+        try contentsOfDirectory(at: dirUrl, includingPropertiesForKeys: includingPropertiesForKeys, options: options)
+    }
+    
     /// Ensures that a file url can be written to.
     public func prepareForWriting(
         to url: URL,

--- a/Sources/SpeziFoundation/Misc/FileManager.swift
+++ b/Sources/SpeziFoundation/Misc/FileManager.swift
@@ -1,0 +1,66 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension FileManager {
+    /// An error that can occur with some file system operations
+    public enum FileManagerError: Error {
+        case other(String)
+    }
+    
+    /// Determines whether a file system item exists at the specified file url.
+    public func itemExists(at url: URL) -> Bool {
+        fileExists(atPath: url.path)
+    }
+    
+    /// Determines whether a file system item exists at the specified file url, and indicates whether the item is a directory.
+    public func itemExists(at url: URL, isDirectory: inout Bool) -> Bool {
+        var flag = ObjCBool(false)
+        defer { isDirectory = flag.boolValue }
+        return fileExists(atPath: url.path, isDirectory: &flag)
+    }
+
+    
+    /// Determines whether a directory exists at the specified file url.
+    public func isDirectory(at url: URL) -> Bool {
+        var isDirectory = false
+        return itemExists(at: url, isDirectory: &isDirectory) && isDirectory
+    }
+    
+    
+    /// Ensures that a file url can be written to.
+    public func prepareForWriting(
+        to url: URL,
+        intermediateDirectoriesAttributes: [FileAttributeKey: Any]? = nil // swiftlint:disable:this discouraged_optional_collection
+    ) throws {
+        let dir = url.deletingLastPathComponent()
+        if !isDirectory(at: dir) {
+            try self.createDirectory(at: dir, withIntermediateDirectories: true, attributes: intermediateDirectoriesAttributes)
+        }
+    }
+
+    
+    /// Copies the item at `srcUrl` to `dstUrl`.
+    public func copyItem(at srcUrl: URL, to dstUrl: URL, overwriteExisting: Bool) throws {
+        if !itemExists(at: dstUrl) {
+            try self.prepareForWriting(to: dstUrl)
+            try self.copyItem(at: srcUrl, to: dstUrl)
+        } else {
+            guard overwriteExisting else {
+                throw FileManagerError.other("Destination file already exists at location '\(dstUrl.path)'")
+            }
+            let tempUrl = URL.temporaryDirectory
+                .appending(component: UUID().uuidString)
+                .appendingPathExtension(srcUrl.pathExtension)
+            try self.copyItem(at: srcUrl, to: tempUrl)
+            _ = try self.replaceItemAt(dstUrl, withItemAt: tempUrl)
+        }
+    }
+}

--- a/Sources/SpeziFoundation/Misc/FormatStyle.swift
+++ b/Sources/SpeziFoundation/Misc/FormatStyle.swift
@@ -1,0 +1,29 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension Date.FormatStyle {
+    /// Modifies the `FormatStyle` to use the specified calendar.
+    @inlinable
+    public func calendar(_ cal: Calendar) -> Self {
+        var copy = self
+        copy.calendar = cal
+        copy.timeZone = cal.timeZone
+        return copy
+    }
+    
+    /// Modifies the `FormatStyle` to use the specified time zone.
+    @inlinable
+    public func timeZone(_ timeZone: TimeZone) -> Self {
+        var copy = self
+        copy.timeZone = timeZone
+        return copy
+    }
+}

--- a/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
+++ b/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
@@ -116,8 +116,9 @@ extension RangeReplaceableCollection {
 
 extension Collection {
     /// Safely accesses the elememt at the specified index, returning `nil` for out-of-bounds indices.
+    @inlinable
     public subscript(safe index: Index) -> Element? {
-        indices.contains(index) ? self[index] : nil
+        index >= startIndex && index < endIndex ? self[index] : nil
     }
 }
 

--- a/Sources/SpeziFoundation/Misc/String.swift
+++ b/Sources/SpeziFoundation/Misc/String.swift
@@ -14,4 +14,11 @@ extension StringProtocol {
     public func trimmingWhitespace() -> SubSequence {
         trimming(while: \.isWhitespace)
     }
+    
+    /// Removes all leading and trailing whitespace (including newlines) from the string.
+    @inlinable
+    @_disfavoredOverload
+    public func trimmingWhitespace() -> String {
+        String(trimmingWhitespace())
+    }
 }

--- a/Sources/SpeziFoundation/Misc/String.swift
+++ b/Sources/SpeziFoundation/Misc/String.swift
@@ -1,0 +1,17 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Algorithms
+
+extension StringProtocol {
+    /// Removes all leading and trailing whitespace (including newlines) from the string.
+    @inlinable
+    public func trimmingWhitespace() -> SubSequence {
+        trimming(while: \.isWhitespace)
+    }
+}

--- a/Sources/SpeziFoundation/SharedRepository/Builtin/SendableValueRepository.swift
+++ b/Sources/SpeziFoundation/SharedRepository/Builtin/SendableValueRepository.swift
@@ -9,7 +9,7 @@
 
 /// A Sendable Shared Repository.
 public struct SendableValueRepository<Anchor> {
-    private var storage: [ObjectIdentifier: AnyRepositoryValue & Sendable] = [:]
+    private var storage: [ObjectIdentifier: any AnyRepositoryValue & Sendable] = [:]
 
 
     /// Initializes an empty shared repository.
@@ -35,7 +35,7 @@ extension SendableValueRepository: SendableSharedRepository {
 
 
 extension SendableValueRepository: Collection {
-    public typealias Index = Dictionary<ObjectIdentifier, AnyRepositoryValue & Sendable>.Index
+    public typealias Index = Dictionary<ObjectIdentifier, any AnyRepositoryValue & Sendable>.Index
 
     public var startIndex: Index {
         storage.values.startIndex
@@ -50,7 +50,7 @@ extension SendableValueRepository: Collection {
     }
 
 
-    public subscript(position: Index) -> AnyRepositoryValue & Sendable {
+    public subscript(position: Index) -> any AnyRepositoryValue & Sendable {
         storage.values[position]
     }
 }

--- a/Sources/SpeziFoundation/SharedRepository/Builtin/ValueRepository.swift
+++ b/Sources/SpeziFoundation/SharedRepository/Builtin/ValueRepository.swift
@@ -9,7 +9,7 @@
 
 /// A Shared Repository.
 public struct ValueRepository<Anchor> {
-    private var storage: [ObjectIdentifier: AnyRepositoryValue] = [:]
+    private var storage: [ObjectIdentifier: any AnyRepositoryValue] = [:]
 
 
     /// Initializes an empty shared repository.
@@ -35,7 +35,7 @@ extension ValueRepository: SharedRepository {
 
 
 extension ValueRepository: Collection {
-    public typealias Index = Dictionary<ObjectIdentifier, AnyRepositoryValue>.Index
+    public typealias Index = Dictionary<ObjectIdentifier, any AnyRepositoryValue>.Index
 
     public var startIndex: Index {
         storage.values.startIndex
@@ -50,7 +50,7 @@ extension ValueRepository: Collection {
     }
 
 
-    public subscript(position: Index) -> AnyRepositoryValue {
+    public subscript(position: Index) -> any AnyRepositoryValue {
         storage.values[position]
     }
 }

--- a/Sources/SpeziFoundation/SpeziFoundation.docc/Calendar.md
+++ b/Sources/SpeziFoundation/SpeziFoundation.docc/Calendar.md
@@ -57,3 +57,4 @@ Improved DST handling for Foundation's TimeZone type.
 - ``Foundation/TimeZone/DSTTransition``
 - ``Foundation/TimeZone/nextDSTTransition(after:)``
 - ``Foundation/TimeZone/nextDSTTransitions(maxCount:)``
+- ``Foundation/TimeZone/losAngeles``

--- a/Sources/SpeziFoundation/SpeziFoundation.docc/Calendar.md
+++ b/Sources/SpeziFoundation/SpeziFoundation.docc/Calendar.md
@@ -45,6 +45,10 @@ Extensions on the `Calendar` and `TimeZone` types, implementing operations
 - ``Foundation/Calendar/numberOfDaysInMonth(for:)``
 - ``Foundation/Calendar/offsetInDays(from:to:)``
 
+### Date FormatStyle
+- ``Foundation/Date/FormatStyle/calendar(_:)``
+- ``Foundation/Date/FormatStyle/timeZone(_:)``
+
 
 ### Time Zone
 

--- a/Sources/SpeziFoundation/SpeziFoundation.docc/SpeziFoundation.md
+++ b/Sources/SpeziFoundation/SpeziFoundation.docc/SpeziFoundation.md
@@ -55,6 +55,9 @@ Spezi Foundation provides a base layer of functionality useful in many applicati
 - ``TimeoutError``
 - ``withTimeout(of:perform:)``
 
+### Markdown
+- ``MarkdownDocument``
+
 ### Objective-C Exception Handling
 - ``catchingNSException(_:)``
 - ``CaughtNSException``

--- a/Tests/SpeziFoundationTests/CalendarExtensionsTests.swift
+++ b/Tests/SpeziFoundationTests/CalendarExtensionsTests.swift
@@ -15,12 +15,12 @@ private struct RegionConfiguration: Hashable {
     
     static let losAngeles = Self(
         locale: .init(identifier: "en_US"),
-        timeZone: .init(identifier: "America/Los_Angeles")! // swiftlint:disable:this force_unwrapping
+        timeZone: .losAngeles
     )
     
     static let berlin = Self(
         locale: .init(identifier: "en_DE"),
-        timeZone: .init(identifier: "Europe/Berlin")! // swiftlint:disable:this force_unwrapping
+        timeZone: .berlin
     )
     
     static let current = Self(locale: .current, timeZone: .current)
@@ -347,5 +347,11 @@ final class CalendarExtensionsTests: XCTestCase { // swiftlint:disable:this type
             XCTAssertEqual(cal.numberOfDaysInMonth(for: try makeDate(year: 2025, month: 02, day: 01, hour: 00)), 28)
             XCTAssertEqual(cal.numberOfDaysInMonth(for: try makeDate(year: 2024, month: 02, day: 01, hour: 00)), 29)
         }
+    }
+    
+    func testTimeZoneConstants() throws {
+        let date = try XCTUnwrap(cal.date(from: .init(year: 2025, month: 07, day: 17)))
+        XCTAssertEqual(TimeZone.losAngeles.secondsFromGMT(for: date), -(7 * 60 * 60))
+        XCTAssertEqual(TimeZone.berlin.secondsFromGMT(for: date), 2 * 60 * 60)
     }
 }

--- a/Tests/SpeziFoundationTests/CollectionBuildersTests.swift
+++ b/Tests/SpeziFoundationTests/CollectionBuildersTests.swift
@@ -23,6 +23,11 @@ final class CollectionBuildersTests: XCTestCase {
     }
     
     
+    private func mightThrow<T>(_ value: T) throws -> T {
+        value
+    }
+    
+    
     func testArrayBuilder() {
         _imp([Int].self, expected: [1, 2, 3, 4, 5, 7, 8, 9, 52, 41]) {
             1
@@ -41,7 +46,6 @@ final class CollectionBuildersTests: XCTestCase {
                 41
             }
         }
-        
         XCTAssertEqual(Array<Int> {}, []) // swiftlint:disable:this syntactic_sugar
     }
     
@@ -49,7 +53,6 @@ final class CollectionBuildersTests: XCTestCase {
         let greet = {
             "Hello, \($0 as String) 🚀\n"
         }
-        
         _imp(
             String.self,
             expected: """
@@ -90,7 +93,6 @@ final class CollectionBuildersTests: XCTestCase {
     
     func testSetBuilder() {
         XCTAssertEqual(Set<Int> {}, Set<Int>())
-        
         let greet = {
             "Hello, \($0 as String) 🚀"
         }
@@ -137,5 +139,21 @@ final class CollectionBuildersTests: XCTestCase {
             "c"
         ]
         XCTAssertEqual(set, expected)
+    }
+    
+    
+    func testArrayBuilderThrowing() throws {
+        let array1: [Int] = Array {
+            1
+            2
+            3
+        }
+        let array2: [Int] = try Array {
+            1
+            try mightThrow(2)
+            3
+        }
+        XCTAssertEqual(array1, [1, 2, 3])
+        XCTAssertEqual(array2, [1, 2, 3])
     }
 }

--- a/Tests/SpeziFoundationTests/CompressionAlgorithmTests.swift
+++ b/Tests/SpeziFoundationTests/CompressionAlgorithmTests.swift
@@ -1,0 +1,31 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SpeziFoundation
+import Testing
+
+
+@Suite
+struct CompressionAlgorithmTests {
+    @Test
+    func zlib() throws {
+        let input = try #require(String(repeating: "Hello Spezi :)", count: 1000).data(using: .utf8))
+        let compressed = try input.compressed(using: Zlib.self)
+        #expect(input.count == 14_000)
+        #expect(compressed.count == 70)
+        #expect(compressed == Data([
+            120, 218, 237, 199, 49, 13, 0, 32, 12, 0, 48, 43, 188, 88, 64, 193, 126, 52, 236,
+            32, 89, 2, 55, 234, 241, 192, 221, 126, 141, 172, 218, 109, 158, 188, 171, 141,
+            30, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102,
+            102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 95, 123, 147, 122, 25, 223
+        ]))
+        let decompressed = try compressed.decompressed(using: Zlib.self)
+        #expect(decompressed == input)
+    }
+}

--- a/Tests/SpeziFoundationTests/FileManagerTests.swift
+++ b/Tests/SpeziFoundationTests/FileManagerTests.swift
@@ -1,0 +1,73 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+@testable import SpeziFoundation
+import Testing
+import UniformTypeIdentifiers
+
+
+@Suite
+@MainActor
+final class FileManagerTests {
+    private let fileManager = FileManager.default
+    private let testRoot = URL.temporaryDirectory.appending(path: "SpeziFoundationFileManagerTests", directoryHint: .isDirectory)
+    
+    init() throws {
+        try? fileManager.removeItem(at: testRoot)
+        try fileManager.createDirectory(at: testRoot, withIntermediateDirectories: false)
+        print("\(Self.self) using testRoot: \(testRoot.path)")
+    }
+    
+    @Test
+    func doStuff() throws {
+        #expect(try fileManager.contents(of: testRoot).isEmpty)
+        let data = Data("HelloWorld".utf8)
+        let fileUrl = testRoot.appendingPathComponent("file", conformingTo: .plainText)
+        try data.write(to: fileUrl)
+        #expect(try fileManager.contents(of: testRoot).mapIntoSet { $0.resolvingSymlinksInPath() } == [fileUrl])
+        
+        let folder1Url = testRoot.appending(path: "folder1", directoryHint: .isDirectory)
+        let folder1File1Url = folder1Url.appendingPathComponent("file1", conformingTo: .plainText)
+        #expect(!fileManager.itemExists(at: folder1Url))
+        #expect(!fileManager.itemExists(at: folder1File1Url))
+        #expect(!fileManager.isDirectory(at: folder1Url))
+        #expect(throws: (any Error).self)  {
+            try data.write(to: folder1File1Url)
+        }
+        try fileManager.prepareForWriting(to: folder1File1Url)
+        try data.write(to: folder1File1Url)
+        #expect(try fileManager.contents(of: testRoot).mapIntoSet { $0.resolvingSymlinksInPath() } == [fileUrl, folder1Url])
+        #expect(try fileManager.contents(of: folder1Url).mapIntoSet(\.lastPathComponent) == ["file1.txt"])
+        #expect(fileManager.itemExists(at: testRoot))
+        #expect(fileManager.itemExists(at: fileUrl))
+        #expect(fileManager.itemExists(at: folder1Url))
+        #expect(fileManager.itemExists(at: folder1File1Url))
+        #expect(fileManager.isDirectory(at: folder1Url))
+        
+        let folder2Url = testRoot.appending(path: "folder2", directoryHint: .isDirectory)
+        try fileManager.copyItem(at: folder1Url, to: folder2Url, overwriteExisting: false)
+        #expect(try fileManager.contents(of: testRoot).mapIntoSet { $0.resolvingSymlinksInPath() } == [fileUrl, folder1Url, folder2Url])
+        do {
+            let folder1Contents = try fileManager.contents(of: folder1Url).mapIntoSet(\.lastPathComponent)
+            let folder2Contents = try fileManager.contents(of: folder2Url).mapIntoSet(\.lastPathComponent)
+            #expect(folder1Contents == folder2Contents)
+        }
+        
+        let folder1File2Url = folder1Url.appendingPathComponent("file2", conformingTo: .plainText)
+        try data.write(to: folder1File2Url)
+        #expect(try fileManager.contents(of: folder1Url).mapIntoSet(\.lastPathComponent) == ["file1.txt", "file2.txt"])
+        
+        #expect(throws: (any Error).self) {
+            try self.fileManager.copyItem(at: folder1Url, to: folder2Url, overwriteExisting: false)
+        }
+        #expect(try fileManager.contents(of: folder2Url).mapIntoSet(\.lastPathComponent) == ["file1.txt"])
+        try fileManager.copyItem(at: folder1Url, to: folder2Url, overwriteExisting: true)
+        #expect(try fileManager.contents(of: folder2Url).mapIntoSet(\.lastPathComponent) == ["file1.txt", "file2.txt"])
+    }
+}

--- a/Tests/SpeziFoundationTests/FormatStyleTests.swift
+++ b/Tests/SpeziFoundationTests/FormatStyleTests.swift
@@ -1,0 +1,52 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SpeziFoundation
+import Testing
+
+
+@Suite
+struct FormatStyleTests {
+    @Test
+    func dateTimeDefaultBehaviours() throws {
+        let timeZoneVatican = try #require(TimeZone(identifier: "Europe/Vatican"))
+        let localeMicronesia = Locale(identifier: "en_FM")
+        
+        var style = Date.FormatStyle()
+        #expect(style.locale == .autoupdatingCurrent)
+        #expect(style.calendar == .autoupdatingCurrent)
+        #expect(style.timeZone == .autoupdatingCurrent)
+        
+        style.timeZone = timeZoneVatican
+        #expect(style.locale == .autoupdatingCurrent)
+        #expect(style.calendar == .autoupdatingCurrent)
+        
+        style.locale = localeMicronesia
+        #expect(style.calendar == .autoupdatingCurrent)
+        #expect(style.timeZone == timeZoneVatican)
+    }
+    
+    @Test
+    func dateTimeExtensions() throws {
+        let timeZoneVatican = try #require(TimeZone(identifier: "Europe/Vatican"))
+        let localeMicronesia = Locale(identifier: "en_FM")
+        let calendarBuddhist = Calendar(identifier: .buddhist)
+        
+        let style = Date.FormatStyle()
+        
+        #expect(style.locale == .autoupdatingCurrent)
+        #expect(style.locale(localeMicronesia).locale == localeMicronesia)
+        
+        #expect(style.calendar == .autoupdatingCurrent)
+        #expect(style.calendar(calendarBuddhist).calendar == calendarBuddhist)
+        
+        #expect(style.timeZone == .autoupdatingCurrent)
+        #expect(style.timeZone(timeZoneVatican).timeZone == timeZoneVatican)
+    }
+}

--- a/Tests/SpeziFoundationTests/ManagedAsynchronousAccessTests.swift
+++ b/Tests/SpeziFoundationTests/ManagedAsynchronousAccessTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class ManagedAsynchronousAccessTests: XCTestCase {
     @MainActor
     func testResumeWithSuccess() async throws {
-        let access = ManagedAsynchronousAccess<String, Error>()
+        let access = ManagedAsynchronousAccess<String, any Error>()
         let expectedValue = "Success"
 
         let expectation = XCTestExpectation(description: "task")
@@ -44,7 +44,7 @@ final class ManagedAsynchronousAccessTests: XCTestCase {
 
     @MainActor
     func testResumeWithError() async throws {
-        let access = ManagedAsynchronousAccess<String, Error>()
+        let access = ManagedAsynchronousAccess<String, any Error>()
 
         let expectation = XCTestExpectation(description: "task")
         Task {
@@ -72,7 +72,7 @@ final class ManagedAsynchronousAccessTests: XCTestCase {
 
     @MainActor
     func testCancelAll() async throws {
-        let access = ManagedAsynchronousAccess<Void, Error>()
+        let access = ManagedAsynchronousAccess<Void, any Error>()
 
         let expectation = XCTestExpectation(description: "task")
         let handle = Task {
@@ -126,7 +126,7 @@ final class ManagedAsynchronousAccessTests: XCTestCase {
     }
 
     func testResumeWithoutOngoingAccess() {
-        let access = ManagedAsynchronousAccess<String, Error>()
+        let access = ManagedAsynchronousAccess<String, any Error>()
 
         let didResume = access.resume(returning: "No Access")
 
@@ -157,7 +157,7 @@ final class ManagedAsynchronousAccessTests: XCTestCase {
 
     @MainActor
     func testExclusiveAccess() async throws {
-        let access = ManagedAsynchronousAccess<String, Error>()
+        let access = ManagedAsynchronousAccess<String, any Error>()
         let expectedValue0 = "Success0"
         let expectedValue1 = "Success1"
 

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -42,50 +42,26 @@ struct MarkdownDocumentTests {
             blocks: []
         ))
     }
-    
+
     @Test
-    func tmp_markdownSectionIdsSimple0() throws {
-        let input = """
-            # First Heading
-            """
-        let doc = try MarkdownDocument(processing: input)
-        #expect(doc == MarkdownDocument(
-            metadata: .init(),
-            blocks: [
-                .markdown(id: "first-heading", rawContents: "# First Heading")
-            ]
-        ))
-    }
-    
-    @Test
-    func tmp_markdownSectionIdsSimple1() throws {
-        let input = """
-            First Heading
-            =============
-            """
-        let doc = try MarkdownDocument(processing: input)
-        #expect(doc == MarkdownDocument(
-            metadata: .init(),
-            blocks: [
-                .markdown(id: "first-heading", rawContents: "First Heading\n=============")
-            ]
-        ))
-    }
-    
-    @Test
-    func tmp_markdownSectionIdsSimple2() throws {
-        let input = """
-            First Heading
-            -------------
-            text
-            """
-        let doc = try MarkdownDocument(processing: input)
-        #expect(doc == MarkdownDocument(
-            metadata: .init(),
-            blocks: [
-                .markdown(id: "first-heading", rawContents: "First Heading\n-------------\ntext")
-            ]
-        ))
+    func metadataCoding() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let metadata: MarkdownDocument.Metadata = [
+            "title": "Study Consent",
+            "version": "1.0.0"
+        ]
+        let encoded = try encoder.encode(metadata)
+        let decoded = try JSONDecoder().decode(MarkdownDocument.Metadata.self, from: encoded)
+        #expect(decoded == metadata)
+        
+        let encoded2 = try encoder.encode([
+            "title": "Study Consent",
+            "version": "1.0.0"
+        ])
+        let decoded2 = try JSONDecoder().decode(MarkdownDocument.Metadata.self, from: encoded2)
+        #expect(encoded2 == encoded)
+        #expect(decoded2 == metadata)
     }
     
     @Test

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -12,7 +12,7 @@ import Testing
 
 
 @Suite
-struct MarkdownDocumentTests {
+struct MarkdownDocumentTests { // swiftlint:disable:this type_body_length
     @Test
     func parse() throws {
         let input = """

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -21,7 +21,7 @@ struct MarkdownDocumentTests {
             """
         let doc = try MarkdownDocument(processing: input)
         #expect(doc == MarkdownDocument(metadata: .init(), blocks: [
-            .markdown("# Hello World\n\nHow are you doing?")
+            .markdown(id: "hello-world", rawContents: "# Hello World\n\nHow are you doing?")
         ]))
     }
     
@@ -40,6 +40,84 @@ struct MarkdownDocumentTests {
                 "version": "1.0.0"
             ],
             blocks: []
+        ))
+    }
+    
+    @Test
+    func tmp_markdownSectionIdsSimple0() throws {
+        let input = """
+            # First Heading
+            """
+        let doc = try MarkdownDocument(processing: input)
+        #expect(doc == MarkdownDocument(
+            metadata: .init(),
+            blocks: [
+                .markdown(id: "first-heading", rawContents: "# First Heading")
+            ]
+        ))
+    }
+    
+    @Test
+    func tmp_markdownSectionIdsSimple1() throws {
+        let input = """
+            First Heading
+            =============
+            """
+        let doc = try MarkdownDocument(processing: input)
+        #expect(doc == MarkdownDocument(
+            metadata: .init(),
+            blocks: [
+                .markdown(id: "first-heading", rawContents: "First Heading\n=============")
+            ]
+        ))
+    }
+    
+    @Test
+    func tmp_markdownSectionIdsSimple2() throws {
+        let input = """
+            First Heading
+            -------------
+            text
+            """
+        let doc = try MarkdownDocument(processing: input)
+        #expect(doc == MarkdownDocument(
+            metadata: .init(),
+            blocks: [
+                .markdown(id: "first-heading", rawContents: "First Heading\n-------------\ntext")
+            ]
+        ))
+    }
+    
+    @Test
+    func markdownSectionIds() throws {
+        let input = """
+            # First Heading
+            ## Second Heading
+            ### Third Heading
+            #### Fourth Heading
+            ##### Fifth Heading
+            ###### Sixth Heading
+            
+            First Heading
+            -------------
+            
+            Second Heading
+            ==============
+            
+            """
+        let doc = try MarkdownDocument(processing: input)
+        #expect(doc == MarkdownDocument(
+            metadata: .init(),
+            blocks: [
+                .markdown(id: "first-heading", rawContents: "# First Heading"),
+                .markdown(id: "second-heading", rawContents: "## Second Heading"),
+                .markdown(id: "third-heading", rawContents: "### Third Heading"),
+                .markdown(id: "fourth-heading", rawContents: "#### Fourth Heading"),
+                .markdown(id: "fifth-heading", rawContents: "##### Fifth Heading"),
+                .markdown(id: "sixth-heading", rawContents: "###### Sixth Heading"),
+                .markdown(id: "first-heading", rawContents: "First Heading\n-------------"),
+                .markdown(id: "second-heading", rawContents: "Second Heading\n==============")
+            ]
         ))
     }
     
@@ -71,7 +149,7 @@ struct MarkdownDocumentTests {
         #expect(doc == MarkdownDocument(
             metadata: .init(),
             blocks: [
-                .markdown("# Hello World\n\nWelcome to our Study"),
+                .markdown(id: "hello-world", rawContents: "# Hello World\n\nWelcome to our Study"),
                 .customElement(.init(
                     name: "toggle",
                     attributes: [
@@ -88,7 +166,7 @@ struct MarkdownDocumentTests {
                         </toggle>
                         """
                 )),
-                .markdown("Selection block:"),
+                .markdown(id: nil, rawContents: "Selection block:"),
                 .customElement(.init(
                     name: "select",
                     attributes: [
@@ -128,7 +206,7 @@ struct MarkdownDocumentTests {
                         </select>
                         """
                 )),
-                .markdown("Please sign the form below:"),
+                .markdown(id: nil, rawContents: "Please sign the form below:"),
                 .customElement(.init(
                     name: "signature",
                     attributes: [.init(name: "id", value: "s1")],

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Foundation
 @testable import SpeziFoundation
 import Testing
 

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -1,0 +1,107 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import SpeziFoundation
+import Testing
+
+
+@Suite
+struct MarkdownDocumentTests {
+    @Test
+    func parse() throws {
+        let input = """
+            # Hello World
+            
+            How are you doing?
+            """
+        let doc = try MarkdownDocument(processing: input)
+        #expect(doc == MarkdownDocument(metadata: .init(), blocks: [
+            .markdown("# Hello World\n\nHow are you doing?")
+        ]))
+    }
+    
+    @Test
+    func metadata() throws {
+        let input = """
+            ---
+            title: Document Title
+            version: 1.0.0
+            ---
+            """
+        let doc = try MarkdownDocument(processing: input)
+        #expect(doc == MarkdownDocument(
+            metadata: [
+                "title": "Document Title",
+                "version": "1.0.0"
+            ],
+            blocks: []
+        ))
+    }
+    
+    @Test
+    func customElements() throws { // swiftlint:disable:this function_body_length
+        let input = """
+            # Hello World
+            
+            Welcome to our Study
+            
+            <toggle id=t1 initial-value=false expected-value=true>
+                I'm fine with some of my health data being used for scientific research.
+            </toggle>
+            
+            Selection block:
+            
+            <select id=s1 initial-value=o1 expected-value="*">
+                Please select a value:
+                <option id=o0>T0</option>
+                <option id=o1>T1</option>
+                Or maybe this one?
+                <option id=o2>T2</option>
+            </select>
+            
+            Please sign the form below:
+            <signature id=s1 />
+            """
+        let doc = try MarkdownDocument(processing: input)
+        #expect(doc == MarkdownDocument(
+            metadata: .init(),
+            blocks: [
+                .markdown("# Hello World\n\nWelcome to our Study"),
+                .customElement(.init(
+                    name: "toggle",
+                    attributes: [
+                        .init(name: "id", value: "t1"),
+                        .init(name: "initial-value", value: "false"),
+                        .init(name: "expected-value", value: "true")
+                    ],
+                    content: [
+                        .text("I'm fine with some of my health data being used for scientific research.")
+                    ]
+                )),
+                .markdown("Selection block:"),
+                .customElement(.init(
+                    name: "select",
+                    attributes: [
+                        .init(name: "id", value: "s1"),
+                        .init(name: "initial-value", value: "o1"),
+                        .init(name: "expected-value", value: "*")
+                    ],
+                    content: [
+                        .text("Please select a value:"),
+                        .element(.init(name: "option", attributes: [.init(name: "id", value: "o0")], content: [.text("T0")])),
+                        .element(.init(name: "option", attributes: [.init(name: "id", value: "o1")], content: [.text("T1")])),
+                        .text("Or maybe this one?"),
+                        .element(.init(name: "option", attributes: [.init(name: "id", value: "o2")], content: [.text("T2")]))
+                    ]
+                )),
+                .markdown("Please sign the form below:"),
+                .customElement(.init(name: "signature", attributes: [.init(name: "id", value: "s1")], content: []))
+            ]
+        ))
+    }
+}

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -67,7 +67,7 @@ struct MarkdownDocumentTests {
             Please sign the form below:
             <signature id=s1 />
             """
-        let doc = try MarkdownDocument(processing: input)
+        let doc = try MarkdownDocument(processing: input, customElementNames: ["toggle", "select", "signature", "option"])
         #expect(doc == MarkdownDocument(
             metadata: .init(),
             blocks: [
@@ -81,7 +81,12 @@ struct MarkdownDocumentTests {
                     ],
                     content: [
                         .text("I'm fine with some of my health data being used for scientific research.")
-                    ]
+                    ],
+                    raw: """
+                        <toggle id=t1 initial-value=false expected-value=true>
+                            I'm fine with some of my health data being used for scientific research.
+                        </toggle>
+                        """
                 )),
                 .markdown("Selection block:"),
                 .customElement(.init(
@@ -93,14 +98,43 @@ struct MarkdownDocumentTests {
                     ],
                     content: [
                         .text("Please select a value:"),
-                        .element(.init(name: "option", attributes: [.init(name: "id", value: "o0")], content: [.text("T0")])),
-                        .element(.init(name: "option", attributes: [.init(name: "id", value: "o1")], content: [.text("T1")])),
+                        .element(.init(
+                            name: "option",
+                            attributes: [.init(name: "id", value: "o0")],
+                            content: [.text("T0")],
+                            raw: "<option id=o0>T0</option>"
+                        )),
+                        .element(.init(
+                            name: "option",
+                            attributes: [.init(name: "id", value: "o1")],
+                            content: [.text("T1")],
+                            raw: "<option id=o1>T1</option>"
+                        )),
                         .text("Or maybe this one?"),
-                        .element(.init(name: "option", attributes: [.init(name: "id", value: "o2")], content: [.text("T2")]))
-                    ]
+                        .element(.init(
+                            name: "option",
+                            attributes: [.init(name: "id", value: "o2")],
+                            content: [.text("T2")],
+                            raw: "<option id=o2>T2</option>"
+                        ))
+                    ],
+                    raw: """
+                        <select id=s1 initial-value=o1 expected-value="*">
+                            Please select a value:
+                            <option id=o0>T0</option>
+                            <option id=o1>T1</option>
+                            Or maybe this one?
+                            <option id=o2>T2</option>
+                        </select>
+                        """
                 )),
                 .markdown("Please sign the form below:"),
-                .customElement(.init(name: "signature", attributes: [.init(name: "id", value: "s1")], content: []))
+                .customElement(.init(
+                    name: "signature",
+                    attributes: [.init(name: "id", value: "s1")],
+                    content: [],
+                    raw: "<signature id=s1 />"
+                ))
             ]
         ))
     }

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -115,6 +115,7 @@ struct MarkdownDocumentTests { // swiftlint:disable:this type_body_length
         #expect(document.blocks == [
             .markdown(id: nil, rawContents: "First markdown block\n- abc\n- def")
         ])
+        #expect(try MarkdownDocument.Metadata(parsing: input) == document.metadata)
     }
 
     


### PR DESCRIPTION
# move some APIs into SpeziFoundation

## :recycle: Current situation & Problem
This PR aims to consolidate some useful extensions / utilities which are currently scattered across multiple other Spezi packages and apps, and move them into SpeziFoundation:
- a `CompressionAlgorithm` protocol & API (coming from MHC)
- some `FileManager` extensions (coming from MHC)
- `MarkdownDocument` and its associated `MarkdownDocument.Parser` (coming from SpeziOnboarding), which enables processing of markdown documents using some small (custom) syntax extensions, such as:
    - frontmatter metadata parsing
    - custom (HTML-based) element parsing/processing

## :gear: Release Notes
see above


## :books: Documentation
new code is documented

## :white_check_mark: Testing
the new APIs are fully tested


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
