### PR TITLE
improve docs, improve parsing, improve tests

### DIFF
--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Parser.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Parser.swift
@@ -8,6 +8,7 @@
 
 // swiftlint:disable file_length
 
+import Algorithms
 import Foundation
 
 
@@ -460,13 +461,17 @@ extension MarkdownDocument.Parser {
     fileprivate static func markdownBlockId(_ content: some StringProtocol) -> String? {
         func makeId(title: some StringProtocol) -> String? {
             let title = title.trimmingWhitespace()
+            let isValidChar = { (char: Character) in
+                char.isASCII && char.isLetter
+            }
             return if title.isEmpty {
                 nil
             } else {
                 title.lazy
-                    .flatMap { $0.lowercased() }
+                    .map { $0.asciiLowercased ?? $0 }
+                    .trimming { !isValidChar($0) }
                     .reduce(into: "") { id, char in
-                        id.append(char.isASCII && char.isLetter ? char : "-")
+                        id.append(isValidChar(char) ? char : "-")
                     }
             }
         }
@@ -512,5 +517,12 @@ extension Character {
     
     fileprivate var isValidIdent: Bool {
         isValidIdentStart || (self >= "0" && self <= "9") || self == "-"
+    }
+    
+    fileprivate var asciiLowercased: Character? {
+        guard let asciiValue, self >= "A" && self <= "Z" else {
+            return nil
+        }
+        return Character(Unicode.Scalar(asciiValue + 32))
     }
 }

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Parser.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Parser.swift
@@ -458,12 +458,17 @@ extension MarkdownDocument.Parser {
     /// The id produced here is not necessarily suitable for uniquely identifying the block within a ``MarkdownDocument``;
     /// rather we match the behaviour of e.g. GitHub, which turn headings into hyphen-separated identifiers.
     fileprivate static func markdownBlockId(_ content: some StringProtocol) -> String? {
-        func makeId(title: some StringProtocol) -> String {
-            title.lazy
-                .flatMap { $0.lowercased() }
-                .reduce(into: "") { id, char in
-                    id.append(char.isASCII && char.isLetter ? char : "-")
-                }
+        func makeId(title: some StringProtocol) -> String? {
+            let title = title.trimmingWhitespace()
+            return if title.isEmpty {
+                nil
+            } else {
+                title.lazy
+                    .flatMap { $0.lowercased() }
+                    .reduce(into: "") { id, char in
+                        id.append(char.isASCII && char.isLetter ? char : "-")
+                    }
+            }
         }
         
         // a heading can take either of the two following forms: (https://daringfireball.net/projects/markdown/syntax#header)

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
@@ -11,6 +11,18 @@ import Foundation
 
 extension MarkdownDocument {
     /// A unit of content within a ``MarkdownDocument``.
+    ///
+    /// ## Topics
+    ///
+    /// ### Enumeration Cases
+    /// - ``markdown(id:rawContents:)``
+    /// - ``customElement(_:)``
+    ///
+    /// ### Instance Properties
+    /// - ``id``
+    /// - ``isMarkdown``
+    /// - ``isCustomElement``
+    /// - ``customElement``
     public enum Block: Hashable, Sendable {
         /// A block of Markdown text
         case markdown(id: String?, rawContents: String)
@@ -26,7 +38,34 @@ extension MarkdownDocument {
                 element[attribute: "id"]
             }
         }
+        
+        /// Whether this is a Markdown block.
+        public var isMarkdown: Bool {
+            switch self {
+            case .markdown: true
+            case .customElement: false
+            }
+        }
+        
+        /// Whether this is a ``MarkdownDocument/CustomElement`` block.
+        public var isCustomElement: Bool {
+            switch self {
+            case .customElement: true
+            case .markdown: false
+            }
+        }
+        
+        /// The block's ``MarkdownDocument/CustomElement``, if applicable.
+        public var customElement: CustomElement? {
+            switch self {
+            case .customElement(let element):
+                element
+            case .markdown:
+                nil
+            }
+        }
     }
+    
     
     /// A custom element that was parsed from a Markdown string.
     public struct CustomElement: Hashable, Sendable {

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument+Sections.swift
@@ -12,6 +12,8 @@ import Foundation
 extension MarkdownDocument {
     /// A unit of content within a ``MarkdownDocument``.
     ///
+    /// See ``MarkdownDocument`` for more information about blocks.
+    ///
     /// ## Topics
     ///
     /// ### Enumeration Cases
@@ -24,9 +26,9 @@ extension MarkdownDocument {
     /// - ``isCustomElement``
     /// - ``customElement``
     public enum Block: Hashable, Sendable {
-        /// A block of Markdown text
+        /// A block consisting of Markdown text
         case markdown(id: String?, rawContents: String)
-        /// A parsed custom element.
+        /// A block consisting of a parsed custom element.
         case customElement(CustomElement)
         
         /// The block's stable identifier, if available.

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
@@ -38,7 +38,6 @@ import Foundation
 /// > Important: The ``MarkdownDocument`` does not perform any Markdown _parsing_;
 ///     it only performs _processing_ of the Markdown input, in the sense that it splits up the input text into a series of sections of Markdown text, and parses any custom tags that may be contained in the Markdown.
 ///
-/// Additionally, the
 /// For example, creating a ``MarkdownDocument`` from the following Markdown input (which ostensibly consists of two "parts": a markdown part with two sections, and a custom element part with a single signature field):
 /// ```markdown
 /// # Study Consent Form
@@ -49,35 +48,47 @@ import Foundation
 ///
 /// <signature id=sig />
 /// ```
-/// would result in a ``MarkdownDocument`` consisting of a total of three blocks: two markdown blocks (one per section) and one custom element block for the signature:
-/// ```swift
-/// MarkdownDocument(
-///     metadata: [:],
-///     blocks: [
-///         .markdown(
-///             id: "study-consent-form",
-///             rawContents: """
-///                 # Study Consent Form
-///                 Welcome to our study. As part of your participation, you will need to fill out and sign this consent form.
-///                 """
-///         ),
-///         .markdown(
-///             id: "your-rights",
-///             rawContents: """
-///                 ## Your rights
-///                 You have the right to revoke this consent at any time; if you wish to do so, contact us at studies@acme.org
-///                 """
-///         ),
-///         .customElement(
-///             MarkdownDocument.CustomElement(
-///                 name: "signature",
-///                 attributes: [.init(name: "id", value: "sig")],
-///                 raw: "<signature id=sig />"
-///             )
-///         )
-///    ]
-/// )
+/// would result in a ``MarkdownDocument`` consisting of a total of three blocks: two markdown blocks (one per section) and one custom element block for the signature.
+///
+/// ``Block``s can have an ``Block/id``, which is determined based on the block's contents:
+/// - for markdown blocks, the block will have an `id` if the block's markdown text starts with a heading, in which case the `id` will be derived from the heading's text;
+/// - for custom element components, the block's `id` will derived from the element's `id` attribute, if present.
+///
+/// ### Custom Elements
+///
+/// The ``MarkdownDocument`` supports the handling of custom elements embedded within the Markdown input.
+/// This behaviour is opt-in, on a per-element-name basis: the parser will only process custom elements whose name
+/// matches one of the `customElementNames` passed to the ``MarkdownDocument`` initializer.
+/// Any eligible custom elements are parsed into ``Block/customElement(_:)`` blocks;
+/// ineligible elements (i.e., those with names not listed in `customElementNames`) are treated as if they were normal Markdown text,
+/// allowing a downstream Markdown parser to handle them instead.
+///
+/// Custom elements (which are in the parsing result represented by the ``CustomElement`` type) are written using a simple HTML-style syntax, consisting of the following components:
+/// - name: the name of the HTML tag
+/// - attributes: a list of string-based key-value pairs
+/// - content: a list of ``CustomElement/Content-swift.enum`` values,
+///     each of which is either raw text (which itself could possibly be markdown), or another, nested ``CustomElement``.
+///
+/// Some examples:
+/// ```html
+/// <toggle id=toggle-1 initial-value=false>
+///     Do you agree to the terms stated above?
+/// </toggle>
+///
+/// <select id=s1>
+///     What's your preference for a nice vacation?
+///     <option id=o1>Mountains</>
+///     <option id=o2>Beach</option>
+/// </select>
+///
+/// <signature id=s1 />
 /// ```
+///
+/// The parser, while not being a fully fledged HTML parser, can handle parsing of the elements like shown above,
+/// and also comments and some syntactic sugar like omitting the name in the closing tag (e.g., `</>`),
+/// self-closing tags (e.g., `<signature />`), and omitting explicit quotes (`"`) for attribute values that are also valid identifiers
+/// (eg: `id=consent-sig` instead of `id="consent-sig`; both of these will result in the same attribute value.
+///
 ///
 /// ## Topics
 ///

--- a/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
+++ b/Sources/SpeziFoundation/Markdown Document/MarkdownDocument.swift
@@ -9,7 +9,75 @@
 import Foundation
 
 
-/// A Markdown document
+/// A Markdown document.
+///
+/// The ``MarkdownDocument`` struct is a lightweight data type representing a (potentially pre-processed) Markdown document,
+/// consisting of optional metadata, and contents which are represented as a series of ``Block``s.
+///
+/// ### Metadata
+///
+/// When using any of the `processing:` initializers to create a ``MarkdownDocument`` (e.g.: ``init(processing:customElementNames:)-(String,_)``),
+/// any frontmatter-style metadata entries at the very beginning of the input will be parsed into a ``Metadata-swift.struct`` object.
+///
+/// The frontmatter-style metadata takes the following format:
+/// ```
+/// ---
+/// key1: value1
+/// key2: value2
+/// ---
+/// ```
+/// I.e., the metadata is a simple String-based key-value mapping, with one entry per line, that is enclosed within two `---` lines.
+///
+/// - Tip: If you just want to extract the metadata from a Markdown file and don't care about the rest of the document, you can use ``Metadata-swift.struct/init(parsing:)``.
+///
+/// ### Content Blocks
+///
+/// The ``blocks`` property stores the Markdown document's content, split up into a series of ``Block``s.
+/// A block is either a section of Markdown-formatted text (``Block/markdown(id:rawContents:)``, or an extracted ``CustomElement`` (``Block/customElement(_:)``).
+///
+/// > Important: The ``MarkdownDocument`` does not perform any Markdown _parsing_;
+///     it only performs _processing_ of the Markdown input, in the sense that it splits up the input text into a series of sections of Markdown text, and parses any custom tags that may be contained in the Markdown.
+///
+/// Additionally, the
+/// For example, creating a ``MarkdownDocument`` from the following Markdown input (which ostensibly consists of two "parts": a markdown part with two sections, and a custom element part with a single signature field):
+/// ```markdown
+/// # Study Consent Form
+/// Welcome to our study. As part of your participation, you will need to fill out and sign this consent form.
+///
+/// ## Your rights
+/// You have the right to revoke this consent at any time; if you wish to do so, contact us at studies@acme.org
+///
+/// <signature id=sig />
+/// ```
+/// would result in a ``MarkdownDocument`` consisting of a total of three blocks: two markdown blocks (one per section) and one custom element block for the signature:
+/// ```swift
+/// MarkdownDocument(
+///     metadata: [:],
+///     blocks: [
+///         .markdown(
+///             id: "study-consent-form",
+///             rawContents: """
+///                 # Study Consent Form
+///                 Welcome to our study. As part of your participation, you will need to fill out and sign this consent form.
+///                 """
+///         ),
+///         .markdown(
+///             id: "your-rights",
+///             rawContents: """
+///                 ## Your rights
+///                 You have the right to revoke this consent at any time; if you wish to do so, contact us at studies@acme.org
+///                 """
+///         ),
+///         .customElement(
+///             MarkdownDocument.CustomElement(
+///                 name: "signature",
+///                 attributes: [.init(name: "id", value: "sig")],
+///                 raw: "<signature id=sig />"
+///             )
+///         )
+///    ]
+/// )
+/// ```
 ///
 /// ## Topics
 ///

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -539,4 +539,40 @@ struct MarkdownDocumentTests { // swiftlint:disable:this type_body_length
             ]
         ))
     }
+    
+    @Test
+    func attrValue0() throws {
+        let input = """
+            <elem id="hello world" />
+            """
+        let document = try MarkdownDocument(processing: input, customElementNames: ["elem"])
+        #expect(document == MarkdownDocument(metadata: [:], blocks: [
+            .customElement(.init(name: "elem", attributes: [.init(name: "id", value: "hello world")], content: [], raw: input))
+        ]))
+    }
+    
+    @Test(arguments: [
+        #"<elem id=1234 />"#,
+        #"<elem id="1234" />"#
+    ])
+    func attrValue1(input: String) throws {
+        let document = try MarkdownDocument(processing: input, customElementNames: ["elem"])
+        #expect(document == MarkdownDocument(metadata: [:], blocks: [
+            .customElement(.init(name: "elem", attributes: [.init(name: "id", value: "1234")], content: [], raw: input))
+        ]))
+    }
+    
+    @Test
+    func nonAsciiInput() throws {
+        let input = """
+            # Hello World 🏳️‍🌈👨‍🌾👨‍👩‍👦
+            
+            <elem id="👨‍🌾" />
+            """
+        let document = try MarkdownDocument(processing: input, customElementNames: ["elem"])
+        #expect(document == MarkdownDocument(metadata: [:], blocks: [
+            .markdown(id: "hello-world", rawContents: "# Hello World 🏳️‍🌈👨‍🌾👨‍👩‍👦"),
+            .customElement(.init(name: "elem", attributes: [.init(name: "id", value: "👨‍🌾")], content: [], raw: #"<elem id="👨‍🌾" />"#))
+        ]))
+    }
 }

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -273,6 +273,8 @@ struct MarkdownDocumentTests { // swiftlint:disable:this type_body_length
             ]
         ))
         #expect(doc.blocks.map(\.id) == ["hello-world", "t1", nil, "s1", nil, "sig"])
+        #expect(doc.blocks.map(\.isMarkdown) == [true, false, true, false, true, false])
+        #expect(doc.blocks.map(\.isCustomElement) == [false, true, false, true, false, true])
     }
     
     @Test

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -446,4 +446,93 @@ struct MarkdownDocumentTests { // swiftlint:disable:this type_body_length
             ))
         ]))
     }
+    
+    
+    @Test
+    func doccExample() throws {
+        let input = """
+            # Study Consent Form
+            Welcome to our study. As part of your participation, you will need to fill out and sign this consent form.
+            
+            ## Your rights
+            You have the right to revoke this consent at any time; if you wish to do so, contact us at studies@acme.org
+            
+            <signature id=sig />
+            """
+        let document = try MarkdownDocument(processing: input, customElementNames: ["signature"])
+        let expected = MarkdownDocument(
+            metadata: [:],
+            blocks: [
+                .markdown(
+                    id: "study-consent-form",
+                    rawContents: """
+                        # Study Consent Form
+                        Welcome to our study. As part of your participation, you will need to fill out and sign this consent form.
+                        """
+                ),
+                .markdown(
+                    id: "your-rights",
+                    rawContents: """
+                        ## Your rights
+                        You have the right to revoke this consent at any time; if you wish to do so, contact us at studies@acme.org
+                        """
+                ),
+                .customElement(
+                    MarkdownDocument.CustomElement(
+                        name: "signature",
+                        attributes: [.init(name: "id", value: "sig")],
+                        raw: "<signature id=sig />"
+                    )
+                )
+           ]
+        )
+        #expect(document == expected)
+    }
+    
+    @Test
+    func hruleParsing() throws {
+        let input = """
+            ---
+            title: Welcome to the Spezi Ecosystem
+            date: 2025-06-22T14:41:16+02:00
+            ---
+            
+            # Welcome to the Spezi Ecosystem
+            This article aims to provide you with a broad overview of Spezi.
+            
+            <marquee filename="PM5544.png" period=5 />
+            
+            ## Our Modules
+            Spezi is architected to be a highly modular system, allowing your application to ...
+            
+            ---
+            
+            ### SpeziHealthKit
+            text text text
+            """
+        let document = try MarkdownDocument(processing: input, customElementNames: ["marquee"])
+        #expect(document == MarkdownDocument(
+            metadata: [
+                "title": "Welcome to the Spezi Ecosystem",
+                "date": "2025-06-22T14:41:16+02:00"
+            ],
+            blocks: [
+                .markdown(
+                    id: "welcome-to-the-spezi-ecosystem",
+                    rawContents: "# Welcome to the Spezi Ecosystem\nThis article aims to provide you with a broad overview of Spezi."
+                ),
+                .customElement(.init(
+                    name: "marquee",
+                    attributes: [.init(name: "filename", value: "PM5544.png"), .init(name: "period", value: "5")],
+                    content: [],
+                    raw: #"<marquee filename="PM5544.png" period=5 />"#
+                )),
+                .markdown(
+                    id: "our-modules",
+                    rawContents: "## Our Modules\nSpezi is architected to be a highly modular system, allowing your application to ...\n\n---"
+                ),
+                .markdown(id: "spezihealthkit", rawContents: "### SpeziHealthKit\ntext text text")
+            ]
+        ))
+    }
 }

--- a/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
+++ b/Tests/SpeziFoundationTests/MarkdownDocumentTests.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 @testable import SpeziFoundation
 import Testing
@@ -486,7 +488,7 @@ struct MarkdownDocumentTests { // swiftlint:disable:this type_body_length
                         raw: "<signature id=sig />"
                     )
                 )
-           ]
+            ]
         )
         #expect(document == expected)
     }


### PR DESCRIPTION
# improve docs, improve parsing, improve tests

## :recycle: Current situation & Problem
this PR is a follow-up to #33, adding a ton of documentation to the `MarkdownDocument` type, fixing some small bugs in the parser, and adding a couple additional test cases.


## :gear: Release Notes
- fixed some `MarkdownDocument` parser bugs


## :books: Documentation
yes.


## :white_check_mark: Testing
yes.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
