### PR TITLE
SendableMetatype

### DIFF
--- a/Sources/SpeziFoundation/Misc/SendableMetatype.swift
+++ b/Sources/SpeziFoundation/Misc/SendableMetatype.swift
@@ -1,0 +1,13 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+#if compiler(<6.2)
+/// Pre Swift 6.2 typealias for `SendableMetatype` that resolves as `Any` to avoid larger `#if` statements in the code base.
+public typealias SendableMetatype = Any
+#endif


### PR DESCRIPTION
# SendableMetatype

## :recycle: Current situation & Problem
- SendableMetatype is Swift 6.2 and newer only. We could use a lot of `#if` statements but that's not fun. 


## :gear: Release Notes
- Add an `SendableMetatype` type only for anything below 6.2 that results in `Any`.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
