### PR TITLE
add `AnyAsyncSequence` and `AnyAsyncIterator` types

### DIFF
--- a/Sources/SpeziFoundation/Concurrency/AnyAsyncIterator.swift
+++ b/Sources/SpeziFoundation/Concurrency/AnyAsyncIterator.swift
@@ -1,0 +1,54 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+/// A type-erased async iterator.
+public struct AnyAsyncIterator<Element, Failure: Error>: AsyncIteratorProtocol {
+    @usableFromInline var base: any AsyncIteratorProtocol
+    
+    /// Creates an async iterator that wraps a base iterator but whose type depends only on the base iterator's `Element` and `Failure` types.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @inlinable
+    public init(_ base: some AsyncIteratorProtocol<Element, Failure>) {
+        self.base = base
+    }
+    
+    /// Creates an async iterator that wraps a base iterator but whose type depends only on the base iterator's `Element` type.
+    @_disfavoredOverload
+    @inlinable
+    public init<I: AsyncIteratorProtocol>(_ base: I) where I.Element == Element, Failure == any Error {
+        self.base = base
+    }
+    
+    /// Creates an async iterator that wraps a base iterator but whose type depends only on the base iterator's `Element` type, and assumes it will never throw.
+    ///
+    /// This initializer will forcibly coerce the input iterator into one of a type whose `Failure` is `Never`.
+    /// If the iterator does in fact end up throwing an error, that is a programmer error and will result in the program getting terminated.
+    ///
+    /// - Note: Use this initializer in pre-iOS 18 situations, where `AsyncIteratorProtocol`'s `Failure` type isn't yet available.
+    @inlinable
+    public init<I: AsyncIteratorProtocol>(unsafelyAssumingDoesntThrow base: I) where I.Element == Element, Failure == Never {
+        self.base = base
+    }
+    
+    @inlinable
+    public mutating func next() async throws -> Element? {
+        try await base.next() as? Element
+    }
+    
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @inlinable
+    public mutating func next(isolation actor: isolated (any Actor)?) async throws(Failure) -> Element? {
+        do {
+            return try await base.next(isolation: actor) as? Element
+        } catch {
+            // SAFETY: our initializers only allow creating `AnyAsyncIterator`s with a matching `Failure` type
+            throw error as! Failure // swiftlint:disable:this force_cast
+        }
+    }
+}

--- a/Sources/SpeziFoundation/Concurrency/AnyAsyncSequence.swift
+++ b/Sources/SpeziFoundation/Concurrency/AnyAsyncSequence.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+/// A type-erased wrapper over an `AsyncSequence`.
+public struct AnyAsyncSequence<Element, Failure: Error>: AsyncSequence {
+    @usableFromInline let makeIterator: () -> AnyAsyncIterator<Element, Failure>
+    
+    /// Creates an `AnyAsyncSequence` that wraps the given `AsyncSequence`
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @inlinable
+    public init(_ base: some AsyncSequence<Element, Failure>) {
+        makeIterator = {
+            AnyAsyncIterator(base.makeAsyncIterator())
+        }
+    }
+    
+    /// Creates an `AnyAsyncSequence` that wraps the given `AsyncSequence`
+    @_disfavoredOverload
+    @inlinable
+    public init<S: AsyncSequence>(_ base: S) where S.Element == Element, Failure == any Error {
+        makeIterator = {
+            AnyAsyncIterator(base.makeAsyncIterator())
+        }
+    }
+    
+    /// Creates an `AnyAsyncSequence` that wraps the given `AsyncSequence` and assumes it will never throw.
+    ///
+    /// This initializer will forcibly coerce the input sequence into one of a type whose `Failure` is `Never`.
+    /// If the sequence does in fact end up throwing an error, that is a programmer error and will result in the program getting terminated.
+    ///
+    /// - Note: Use this initializer in pre-iOS 18 situations, where `AsyncSequence`'s `Failure` type isn't yet available.
+    @inlinable
+    public init<S: AsyncSequence>(unsafelyAssumingDoesntThrow base: S) where S.Element == Element, Failure == Never {
+        makeIterator = {
+            AnyAsyncIterator(unsafelyAssumingDoesntThrow: base.makeAsyncIterator())
+        }
+    }
+    
+    @inlinable
+    public func makeAsyncIterator() -> AnyAsyncIterator<Element, Failure> {
+        makeIterator()
+    }
+}

--- a/Tests/SpeziFoundationTests/AnyAsyncSequenceTests.swift
+++ b/Tests/SpeziFoundationTests/AnyAsyncSequenceTests.swift
@@ -1,0 +1,109 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+// Tests adopted from https://github.com/groue/Semaphore/blob/main/Sources/Semaphore/AsyncSemaphore.swift.
+//
+
+@testable import SpeziFoundation
+import Testing
+
+
+@Suite
+struct AnyAsyncSequenceTests {
+    private func getCountingSequence<T: Sendable>(
+        for range: Range<T>,
+        interval: Duration = .seconds(0.01)
+    ) -> AsyncStream<T> where T: Strideable, T.Stride: SignedInteger {
+        let (stream, continuation) = AsyncStream.makeStream(of: T.self)
+        Task {
+            for element in range {
+                try await Task.sleep(for: interval)
+                continuation.yield(element)
+            }
+            continuation.finish()
+        }
+        return stream
+    }
+    
+    private func collect<S: AsyncSequence>(_ sequence: S) async throws -> [S.Element] {
+        var elements: [S.Element] = []
+        for try await element in sequence {
+            elements.append(element)
+        }
+        return elements
+    }
+    
+    
+    @Test
+    func sequence0() async throws {
+        let seq = getCountingSequence(for: 0..<500)
+        #expect(try await collect(seq) == Array(0..<500))
+    }
+    
+    
+    @Test
+    func sequence1A() async throws {
+        let seq = AnyAsyncSequence(getCountingSequence(for: 0..<500))
+        #expect(try await collect(seq) == Array(0..<500))
+    }
+    
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sequence1B() async throws {
+        let seq = AnyAsyncSequence(getCountingSequence(for: 0..<500))
+        #expect(try await collect(seq) == Array(0..<500))
+    }
+    
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sequence1C() async throws {
+        let seq = AnyAsyncSequence(unsafelyAssumingDoesntThrow: getCountingSequence(for: 0..<500))
+        #expect(try await collect(seq) == Array(0..<500))
+    }
+    
+    
+    @Test
+    func sequence2A() async throws {
+        let seq = AnyAsyncSequence(getCountingSequence(for: 0..<500).filter { $0 < 250 })
+        #expect(try await collect(seq) == Array(0..<250))
+    }
+    
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sequence2B() async throws {
+        let seq = AnyAsyncSequence(getCountingSequence(for: 0..<500).filter { $0 < 250 })
+        #expect(try await collect(seq) == Array(0..<250))
+    }
+    
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sequence2C() async throws {
+        let seq = AnyAsyncSequence(unsafelyAssumingDoesntThrow: getCountingSequence(for: 0..<500).filter { $0 < 250 })
+        #expect(try await collect(seq) == Array(0..<250))
+    }
+    
+    
+    @Test
+    func sequence3A() async throws {
+        let seq = AnyAsyncSequence(getCountingSequence(for: 0..<500)).filter { $0 < 250 }
+        #expect(try await collect(seq) == Array(0..<250))
+    }
+    
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sequence3B() async throws {
+        let seq = AnyAsyncSequence(getCountingSequence(for: 0..<500)).filter { $0 < 250 }
+        #expect(try await collect(seq) == Array(0..<250))
+    }
+    
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sequence3C() async throws {
+        let seq = AnyAsyncSequence(unsafelyAssumingDoesntThrow: getCountingSequence(for: 0..<500)).filter { $0 < 250 }
+        #expect(try await collect(seq) == Array(0..<250))
+    }
+}


### PR DESCRIPTION
# add `AnyAsyncSequence` and `AnyAsyncIterator` types

## :recycle: Current situation & Problem
we currently have an `AnyAsyncSequence` and an `AnyAsyncIterator` in the SpeziOneSecInterface package; this PR moves them over to SpeziFoundation so that other packages may benefit from them as well.

## :gear: Release Notes
- added `AnyAsyncSequence` and `AnyAsyncIterator` types

## :books: Documentation
the new types are documented

## :white_check_mark: Testing
yes


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
