### PR TITLE
expose localized resource candidate selection

### DIFF
--- a/Sources/SpeziLocalization/LocalizedFileResources/LocalizedFileResolution.swift
+++ b/Sources/SpeziLocalization/LocalizedFileResources/LocalizedFileResolution.swift
@@ -108,6 +108,17 @@ extension LocalizedFileResolution {
         }
         return nil
     }
+    
+    
+    /// Selects all candidates that might match `resource`, ignoring the specified locale.
+    public static func selectCandidatesIgnoringLocalization(
+        matching resource: LocalizedFileResource,
+        from candidates: some Collection<URL>
+    ) -> [LocalizedFileResource.Resolved] {
+        candidates.lazy
+            .compactMap { LocalizedFileResource.Resolved(resource: resource, url: $0) }
+            .filter { $0.url.matches(unlocalizedFilename: resource.name) }
+    }
 }
 
 


### PR DESCRIPTION
# expose localized resource candidate selection

## :recycle: Current situation & Problem
this PR exposes SpeziLocalization's localized resource matching candidate selection API. this allows users to obtain the list of all files that match a `LocalizedFileResource`, and perform manual work on that.

(the more narrower use case is for SpeziStudy to be able to, given a file references in a study component, determine which of the files included in the study bundle "belong" to this component, i.e. which of the files can match against the file ref.)


## :gear: Release Notes
- added `LocalizedFileResolution.selectCandidatesIgnoringLocalization(matching:from:)`


## :books: Documentation
yes


## :white_check_mark: Testing
*todo*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
