### PR TITLE
deprecate async `Sequence` extensions

### DIFF
--- a/Sources/SpeziFoundation/LocalPreferences/LocalPreference.swift
+++ b/Sources/SpeziFoundation/LocalPreferences/LocalPreference.swift
@@ -129,7 +129,7 @@ private final class UserDefaultsKeyObserver<T: SendableMetatype>: NSObject, Send
         let observation: ObservationInfo
     }
     
-    let lock = RWLock()
+    private let lock = RWLock()
     @ObservationIgnored nonisolated(unsafe) private var state: State?
     // https://github.com/swiftlang/swift/issues/81962
     nonisolated(unsafe) private(set) var viewUpdate: UInt64 = 0

--- a/Sources/SpeziFoundation/LocalPreferences/LocalPreferenceKey.swift
+++ b/Sources/SpeziFoundation/LocalPreferences/LocalPreferenceKey.swift
@@ -45,11 +45,11 @@ public class LocalPreferenceKeys: @unchecked Sendable {}
 /// ## Topics
 ///
 /// ### Creating Keys
-/// - ``init(_:default:)-6dihs``
-/// - ``init(_:default:)-cey3``
+/// - ``init(_:default:)-9hruy``
+/// - ``init(_:default:)-980t1``
 /// - ``init(_:encoder:decoder:default:)``
-/// - ``init(_:)-70fbg``
-/// - ``init(_:)-7o698``
+/// - ``init(_:)-6bb04``
+/// - ``init(_:)-3s1w9``
 /// - ``init(_:encoder:decoder:)``
 ///
 /// ### Instance Properties

--- a/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
+++ b/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
@@ -58,6 +58,7 @@ extension Sequence {
     
     
     /// An asynchronous version of Swift's `Sequence.reduce(_:_:)` function.
+    @available(*, deprecated, message: "Do not use this function. It was a bad idea and does not behave the way one might expect.")
     @inlinable
     public func reduceAsync<Result, E>(
         _ initialResult: Result,
@@ -71,6 +72,7 @@ extension Sequence {
     }
     
     /// An asynchronous version of Swift's `Sequence.reduce(into:_:)` function.
+    @available(*, deprecated, message: "Do not use this function. It was a bad idea and does not behave the way one might expect.")
     @inlinable
     public func reduceAsync<Result, E>(
         into initial: Result,

--- a/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
+++ b/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
@@ -59,7 +59,7 @@ extension Sequence {
     
     /// An asynchronous version of Swift's `Sequence.reduce(_:_:)` function.
     ///
-    /// - Important: Do not use this function. Use an explicit `for` loop (and a task group, if you want concurrency).
+    /// - Important: Do not use this function. Use an explicit `for` loop instead (and a task group, if you want concurrency).
     @available(*, deprecated, message: "Do not use this function. It was a bad idea and does not behave the way one might expect.")
     @inlinable
     public func reduceAsync<Result, E>(
@@ -75,7 +75,7 @@ extension Sequence {
     
     /// An asynchronous version of Swift's `Sequence.reduce(into:_:)` function.
     ///
-    /// - Important: Do not use this function. Use an explicit `for` loop (and a task group, if you want concurrency).
+    /// - Important: Do not use this function. Use an explicit `for` loop instead (and a task group, if you want concurrency).
     @available(*, deprecated, message: "Do not use this function. It was a bad idea and does not behave the way one might expect.")
     @inlinable
     public func reduceAsync<Result, E>(

--- a/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
+++ b/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
@@ -58,6 +58,8 @@ extension Sequence {
     
     
     /// An asynchronous version of Swift's `Sequence.reduce(_:_:)` function.
+    ///
+    /// - Important: Do not use this function. Use an explicit `for` loop (and a task group, if you want concurrency).
     @available(*, deprecated, message: "Do not use this function. It was a bad idea and does not behave the way one might expect.")
     @inlinable
     public func reduceAsync<Result, E>(
@@ -72,6 +74,8 @@ extension Sequence {
     }
     
     /// An asynchronous version of Swift's `Sequence.reduce(into:_:)` function.
+    ///
+    /// - Important: Do not use this function. Use an explicit `for` loop (and a task group, if you want concurrency).
     @available(*, deprecated, message: "Do not use this function. It was a bad idea and does not behave the way one might expect.")
     @inlinable
     public func reduceAsync<Result, E>(

--- a/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
+++ b/Sources/SpeziFoundation/Misc/SequenceExtensions.swift
@@ -59,8 +59,15 @@ extension Sequence {
     
     /// An asynchronous version of Swift's `Sequence.reduce(_:_:)` function.
     ///
-    /// - Important: Do not use this function. Use an explicit `for` loop instead (and a task group, if you want concurrency).
-    @available(*, deprecated, message: "Do not use this function. It was a bad idea and does not behave the way one might expect.")
+    /// - Important: Do not use this function. Use the apple/swift-async-algorithms package's `Sequence.async` API instead.
+    @available(
+        *,
+        deprecated,
+        message: """
+            Do not use this function. It was a bad idea and does not behave the way one might expect.
+            Use the apple/swift-async-algorithms package's `Sequence.async` API instead.
+            """
+    )
     @inlinable
     public func reduceAsync<Result, E>(
         _ initialResult: Result,
@@ -75,8 +82,15 @@ extension Sequence {
     
     /// An asynchronous version of Swift's `Sequence.reduce(into:_:)` function.
     ///
-    /// - Important: Do not use this function. Use an explicit `for` loop instead (and a task group, if you want concurrency).
-    @available(*, deprecated, message: "Do not use this function. It was a bad idea and does not behave the way one might expect.")
+    /// - Important: Do not use this function. Use the apple/swift-async-algorithms package's `Sequence.async` API instead.
+    @available(
+        *,
+        deprecated,
+        message: """
+            Do not use this function. It was a bad idea and does not behave the way one might expect.
+            Use the apple/swift-async-algorithms package's `Sequence.async` API instead.
+            """
+    )
     @inlinable
     public func reduceAsync<Result, E>(
         into initial: Result,

--- a/Sources/SpeziFoundation/SpeziFoundation.docc/CollectionAlgorithms.md
+++ b/Sources/SpeziFoundation/SpeziFoundation.docc/CollectionAlgorithms.md
@@ -22,8 +22,6 @@ Binary search over Collections, and other Sequence extensions
 - ``Swift/Sequence/isSorted(by:)``
 - ``Swift/Sequence/sorted(using:)``
 - ``Swift/Sequence/mapIntoSet(_:)``
-- ``Swift/Sequence/reduceAsync(_:_:)``
-- ``Swift/Sequence/reduceAsync(into:_:)``
 - ``Swift/MutableCollection/sort(using:)``
 - ``Swift/RangeReplaceableCollection/remove(at:)``
 - ``Swift/Collection/subscript(safe:)``

--- a/Tests/SpeziFoundationTests/SequenceExtensionTests.swift
+++ b/Tests/SpeziFoundationTests/SequenceExtensionTests.swift
@@ -47,25 +47,6 @@ struct SequenceExtensions {
         #expect(array == [1, 3, 4, 6, 8, 9])
     }
     
-    @Test
-    func asyncReduce() async throws {
-        let names = ["Paul", "Lukas"]
-        let reduced = try await names.reduceAsync(0) { acc, name in
-            try await Task.sleep(for: .seconds(0.2)) // best i could think of to get some trivial async-ness in here...
-            return acc + name.count
-        }
-        #expect(reduced == 9)
-    }
-    
-    @Test
-    func asyncReduceInto() async throws {
-        let names = ["Paul", "Lukas"]
-        let reduced = try await names.reduceAsync(into: 0) { acc, name in
-            try await Task.sleep(for: .seconds(0.2)) // best i could think of to get some trivial async-ness in here...
-            acc += name.count
-        }
-        #expect(reduced == 9)
-    }
     
     @Test
     func search() {


### PR DESCRIPTION
# deprecate async `Sequence` extensions

## :recycle: Current situation & Problem
issue: in #19, i thought it would be a good idea to add async versions of `Sequence.reduce(_:_:)` and `Sequence.reduce(into:_:)`.
this was actually a bad idea (there is a reason why the stdlib doesn't have this...), since the functions, while being async, and while allowing you to use an async transform function, don't provide any additional benefit.
(one might instinctively assume that the functions would process multiple elements of the input sequence concurrently, to take advantage of the async-ness. they don't.)

callers should simply perform the reduce operation via an explicit for loop, or a task group if they want concurrency.


## :gear: Release Notes
- deprecated `Sequence.reduceAsync(_:_:)` and `Sequence.reduceAsync(into:_:)`


## :books: Documentation
updated


## :white_check_mark: Testing
removed


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).