### PR TITLE
LocalizationsDictionary literal init

### DIFF
--- a/Sources/SpeziLocalization/LocalizedFileResources/LocalizationsDictionary.swift
+++ b/Sources/SpeziLocalization/LocalizedFileResources/LocalizationsDictionary.swift
@@ -46,7 +46,8 @@ import Foundation
 ///
 /// ### Initializers
 /// - ``init()``
-/// - ``init(_:)``
+/// - ``init(_:)-([LocalizationKey:Value])``
+/// - ``init(_:)-(Sequence<(LocalizationKey,Value)>)``
 ///
 /// ### Subscripts
 /// - ``subscript(_:using:fallback:)``
@@ -58,10 +59,20 @@ public struct LocalizationsDictionary<Value> {
     public init() {
         self.storage = [:]
     }
-
+    
     /// Creates a localizations dictionary from the given entries.
     public init(_ entries: [LocalizationKey: Value]) {
         self.storage = entries
+    }
+
+    /// Creates a localizations dictionary from the given entries.
+    ///
+    /// If the sequence contains multiple elements with the same key, latter occurrences will override earlier ones.
+    public init(_ entries: some Sequence<(LocalizationKey, Value)>) {
+        self.init()
+        for (key, value) in entries {
+            storage[key] = value
+        }
     }
 
     /// Resolves the best value for the given localization key.
@@ -144,5 +155,12 @@ extension LocalizationsDictionary: Collection {
 
     public subscript(position: Index) -> Element {
         storage[position]
+    }
+}
+
+
+extension LocalizationsDictionary: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (LocalizationKey, Value)...) {
+        self.init(elements)
     }
 }

--- a/Tests/SpeziLocalizationTests/LocalizationsDictionaryTests.swift
+++ b/Tests/SpeziLocalizationTests/LocalizationsDictionaryTests.swift
@@ -233,4 +233,16 @@ struct LocalizationsDictionaryTests {
         #expect(dict[key] == "Hi")
         #expect(dict.count == 1)
     }
+    
+    
+    @Test
+    func dictionaryLiteralInit() {
+        let dict: LocalizationsDictionary<String> = [
+            .enUS: "Hello",
+            .deDE: "Hallo"
+        ]
+        #expect(dict[.enUS] == "Hello")
+        #expect(dict[.deDE] == "Hallo")
+        #expect(dict[.enUK] == "Hello")
+    }
 }


### PR DESCRIPTION
# LocalizationsDictionary literal init


## :gear: Release Notes
- LocalizationsDictionary: added a `ExpressibleByDictionaryLiteral` conformance
- LocalizationsDictionary: added a key-value-pairs sequence-based init


## :books: Documentation
yes


## :white_check_mark: Testing
yes


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
